### PR TITLE
Generate documentation XML file

### DIFF
--- a/src/Saturn/Saturn.fsproj
+++ b/src/Saturn/Saturn.fsproj
@@ -5,6 +5,7 @@
     <OutputType>Library</OutputType>
     <TargetFramework>netstandard2.0</TargetFramework>
     <DebugType>portable</DebugType>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />


### PR DESCRIPTION
I was wondering why I couldn't see any documentation in the tooltips until I realized the `GenerateDocumentationFile` property was missing in the .fsproj :)