### PR TITLE
Add basic diagnostics files

### DIFF
--- a/sample/Controller.Sample/Controller.Sample.fs
+++ b/sample/Controller.Sample/Controller.Sample.fs
@@ -33,11 +33,17 @@ let userController = controller {
     edit (fun (ctx, id) -> (sprintf "Edit handler no version - %i" id) |> Controller.text ctx)
 }
 
-let topRouter = scope {
+let otherRouter = scope {
+    get "/dsa" (text "")
+    getf "/dsa/%s" (text)
+    forwardf "/ddd/%s" (fun (a : string) -> userControllerVersion1)
     not_found_handler (setStatusCode 404 >=> text "Not Found")
+}
 
+let topRouter = scope {
     forward "/users" userControllerVersion1
     forward "/users" userController
+    forwardf "/%s/%s/abc" (fun (a : string * string) -> otherRouter)
 }
 
 let app = application {

--- a/src/Saturn/Application.fs
+++ b/src/Saturn/Application.fs
@@ -366,10 +366,16 @@ module Application =
           ServicesConfig = service::state.ServicesConfig
       }
 
+    ///Disables generation of diagnostic files that can be used by Saturn tooling.
+    [<CustomOperation("disable_diagnostics")>]
+    member __.DisableDiagnostics (state) =
+      SiteMap.isDebug <- false
+      state
+
   ///Computation expression used to configure Saturn application
   let application = ApplicationBuilder()
 
   ///Runs Saturn application
   let run (app: IWebHostBuilder) =
-    SiteMap.generate ()
+    if SiteMap.isDebug then SiteMap.generate ()
     app.Build().Run()

--- a/src/Saturn/Application.fs
+++ b/src/Saturn/Application.fs
@@ -370,4 +370,6 @@ module Application =
   let application = ApplicationBuilder()
 
   ///Runs Saturn application
-  let run (app: IWebHostBuilder) = app.Build().Run()
+  let run (app: IWebHostBuilder) =
+    SiteMap.generate ()
+    app.Build().Run()

--- a/src/Saturn/Controller.fs
+++ b/src/Saturn/Controller.fs
@@ -1,6 +1,7 @@
 namespace Saturn
 
 open System
+open SiteMap
 
 [<AutoOpen>]
 module Controller =
@@ -49,6 +50,7 @@ module Controller =
       { Index = None; Show = None; Add = None; Edit = None; Create = None; Update = None; Delete = None; DeleteAll = None; NotFoundHandler = None; Version = None; SubControllers = []; Plugs = Map.empty<_,_>; ErrorHandler = fun (_, ex) -> raise ex }
 
     member __.Run(state : ControllerState<'Key>) : HttpHandler =
+      let siteMap = HandlerMap()
       let typ =
         match state with
         | { Show = None; Edit = None; Update = None; Delete = None; SubControllers = [] } -> None
@@ -73,37 +75,69 @@ module Controller =
       let initialController =
         choose [
           yield GET >=> choose [
-            if state.Add.IsSome then yield addPlugs Add (route "/add" >=> (fun _ ctx -> state.Add.Value(ctx)))
+            if state.Add.IsSome then
+              siteMap.AddPath "/add" "GET"
+              yield addPlugs Add (route "/add" >=> (fun _ ctx -> state.Add.Value(ctx)))
             if state.Edit.IsSome then
               match typ with
               | None -> ()
               | Some k ->
                 match k with
-                | Bool -> yield addPlugs Edit (routef "/%b/edit" (fun input _ ctx -> state.Edit.Value(ctx, unbox<'Key> input)))
-                | Char -> yield addPlugs Edit (routef "/%c/edit" (fun input _ ctx -> state.Edit.Value(ctx, unbox<'Key> input)))
-                | String -> yield addPlugs Edit (routef "/%s/edit" (fun input _ ctx -> state.Edit.Value(ctx, unbox<'Key> input)))
-                | Int32 -> yield addPlugs Edit (routef "/%i/edit" (fun input _ ctx -> state.Edit.Value(ctx, unbox<'Key> input)))
-                | Int64 -> yield addPlugs Edit (routef "/%d/edit" (fun input _ ctx -> state.Edit.Value(ctx, unbox<'Key> input)))
-                | Float -> yield addPlugs Edit (routef "/%f/edit" (fun input _ ctx -> state.Edit.Value(ctx, unbox<'Key> input)))
-                | Guid -> yield addPlugs Edit (routef "/%O/edit" (fun input _ ctx -> state.Edit.Value(ctx, unbox<'Key> input)))
+                | Bool ->
+                  siteMap.AddPath "/%b/edit" "GET"
+                  yield addPlugs Edit (routef "/%b/edit" (fun input _ ctx -> state.Edit.Value(ctx, unbox<'Key> input)))
+                | Char ->
+                  siteMap.AddPath "/%c/edit" "GET"
+                  yield addPlugs Edit (routef "/%c/edit" (fun input _ ctx -> state.Edit.Value(ctx, unbox<'Key> input)))
+                | String ->
+                  siteMap.AddPath "/%s/edit" "GET"
+                  yield addPlugs Edit (routef "/%s/edit" (fun input _ ctx -> state.Edit.Value(ctx, unbox<'Key> input)))
+                | Int32 ->
+                  siteMap.AddPath "/%i/edit" "GET"
+                  yield addPlugs Edit (routef "/%i/edit" (fun input _ ctx -> state.Edit.Value(ctx, unbox<'Key> input)))
+                | Int64 ->
+                  siteMap.AddPath "/%d/edit" "GET"
+                  yield addPlugs Edit (routef "/%d/edit" (fun input _ ctx -> state.Edit.Value(ctx, unbox<'Key> input)))
+                | Float ->
+                  siteMap.AddPath "/%f/edit" "GET"
+                  yield addPlugs Edit (routef "/%f/edit" (fun input _ ctx -> state.Edit.Value(ctx, unbox<'Key> input)))
+                | Guid ->
+                  siteMap.AddPath "/%O/edit" "GET"
+                  yield addPlugs Edit (routef "/%O/edit" (fun input _ ctx -> state.Edit.Value(ctx, unbox<'Key> input)))
             if state.Show.IsSome then
               match typ with
               | None -> ()
               | Some k ->
                 match k with
-                | Bool -> yield addPlugs Show (routef "/%b" (fun input _ ctx -> state.Show.Value(ctx, unbox<'Key> input)))
-                | Char -> yield addPlugs Show (routef "/%c" (fun input _ ctx -> state.Show.Value(ctx, unbox<'Key> input)))
-                | String -> yield addPlugs Show (routef "/%s" (fun input _ ctx -> state.Show.Value(ctx, unbox<'Key> input)))
-                | Int32 -> yield addPlugs Show (routef "/%i" (fun input _ ctx -> state.Show.Value(ctx, unbox<'Key> input)))
-                | Int64 -> yield addPlugs Show (routef "/%d" (fun input _ ctx -> state.Show.Value(ctx, unbox<'Key> input)))
-                | Float -> yield addPlugs Show (routef "/%f" (fun input _ ctx -> state.Show.Value(ctx, unbox<'Key> input)))
-                | Guid -> yield addPlugs Show (routef "/%O" (fun input _ ctx -> state.Show.Value(ctx, unbox<'Key> input)))
+                | Bool ->
+                  siteMap.AddPath "/%b" "GET"
+                  yield addPlugs Show (routef "/%b" (fun input _ ctx -> state.Show.Value(ctx, unbox<'Key> input)))
+                | Char ->
+                  siteMap.AddPath "/%c" "GET"
+                  yield addPlugs Show (routef "/%c" (fun input _ ctx -> state.Show.Value(ctx, unbox<'Key> input)))
+                | String ->
+                  siteMap.AddPath "/%s" "GET"
+                  yield addPlugs Show (routef "/%s" (fun input _ ctx -> state.Show.Value(ctx, unbox<'Key> input)))
+                | Int32 ->
+                  siteMap.AddPath "/%i" "GET"
+                  yield addPlugs Show (routef "/%i" (fun input _ ctx -> state.Show.Value(ctx, unbox<'Key> input)))
+                | Int64 ->
+                  siteMap.AddPath "/%d" "GET"
+                  yield addPlugs Show (routef "/%d" (fun input _ ctx -> state.Show.Value(ctx, unbox<'Key> input)))
+                | Float ->
+                  siteMap.AddPath "/%f" "GET"
+                  yield addPlugs Show (routef "/%f" (fun input _ ctx -> state.Show.Value(ctx, unbox<'Key> input)))
+                | Guid ->
+                  siteMap.AddPath "/%O" "GET"
+                  yield addPlugs Show (routef "/%O" (fun input _ ctx -> state.Show.Value(ctx, unbox<'Key> input)))
             if state.Index.IsSome then
+              siteMap.AddPath "/" "GET"
               yield addPlugs Index (route "" >=> (fun _ ctx -> ctx.Request.Path <- PathString(ctx.Request.Path.ToString() + "/"); state.Index.Value(ctx)))
               yield addPlugs Index (route "/" >=> (fun _ ctx -> state.Index.Value(ctx)))
           ]
           yield POST >=> choose [
             if state.Create.IsSome then
+              siteMap.AddPath "/" "POST"
               yield addPlugs Create (route "" >=> (fun _ ctx -> ctx.Request.Path <- PathString(ctx.Request.Path.ToString() + "/"); state.Create.Value(ctx)))
               yield addPlugs Create (route "/" >=> (fun _ ctx -> state.Create.Value(ctx)))
 
@@ -112,13 +146,27 @@ module Controller =
               | None -> ()
               | Some k ->
                 match k with
-                | Bool -> yield addPlugs Update (routef "/%b" (fun input _ ctx -> state.Update.Value(ctx, unbox<'Key> input)))
-                | Char -> yield addPlugs Update (routef "/%c" (fun input _ ctx -> state.Update.Value(ctx, unbox<'Key> input)))
-                | String -> yield addPlugs Update (routef "/%s" (fun input _ ctx -> state.Update.Value(ctx, unbox<'Key> input)))
-                | Int32 -> yield addPlugs Update (routef "/%i" (fun input _ ctx -> state.Update.Value(ctx, unbox<'Key> input)))
-                | Int64 -> yield addPlugs Update (routef "/%d" (fun input _ ctx -> state.Update.Value(ctx, unbox<'Key> input)))
-                | Float -> yield addPlugs Update (routef "/%f" (fun input _ ctx -> state.Update.Value(ctx, unbox<'Key> input)))
-                | Guid -> yield addPlugs Update (routef "/%O" (fun input _ ctx -> state.Update.Value(ctx, unbox<'Key> input)))
+                | Bool ->
+                  siteMap.AddPath "/%b" "POST"
+                  yield addPlugs Update (routef "/%b" (fun input _ ctx -> state.Update.Value(ctx, unbox<'Key> input)))
+                | Char ->
+                  siteMap.AddPath "/%c" "POST"
+                  yield addPlugs Update (routef "/%c" (fun input _ ctx -> state.Update.Value(ctx, unbox<'Key> input)))
+                | String ->
+                  siteMap.AddPath "/%s" "POST"
+                  yield addPlugs Update (routef "/%s" (fun input _ ctx -> state.Update.Value(ctx, unbox<'Key> input)))
+                | Int32 ->
+                  siteMap.AddPath "/%i" "POST"
+                  yield addPlugs Update (routef "/%i" (fun input _ ctx -> state.Update.Value(ctx, unbox<'Key> input)))
+                | Int64 ->
+                  siteMap.AddPath "/%d" "POST"
+                  yield addPlugs Update (routef "/%d" (fun input _ ctx -> state.Update.Value(ctx, unbox<'Key> input)))
+                | Float ->
+                  siteMap.AddPath "/%f" "POST"
+                  yield addPlugs Update (routef "/%f" (fun input _ ctx -> state.Update.Value(ctx, unbox<'Key> input)))
+                | Guid ->
+                  siteMap.AddPath "/%O" "POST"
+                  yield addPlugs Update (routef "/%O" (fun input _ ctx -> state.Update.Value(ctx, unbox<'Key> input)))
           ]
           yield PATCH >=> choose [
             if state.Update.IsSome then
@@ -126,13 +174,27 @@ module Controller =
               | None -> ()
               | Some k ->
                 match k with
-                | Bool -> yield addPlugs Update (routef "/%b" (fun input _ ctx -> state.Update.Value(ctx, unbox<'Key> input)))
-                | Char -> yield addPlugs Update (routef "/%c" (fun input _ ctx -> state.Update.Value(ctx, unbox<'Key> input)))
-                | String -> yield addPlugs Update (routef "/%s" (fun input _ ctx -> state.Update.Value(ctx, unbox<'Key> input)))
-                | Int32 -> yield addPlugs Update (routef "/%i" (fun input _ ctx -> state.Update.Value(ctx, unbox<'Key> input)))
-                | Int64 -> yield addPlugs Update (routef "/%d" (fun input _ ctx -> state.Update.Value(ctx, unbox<'Key> input)))
-                | Float -> yield addPlugs Update (routef "/%f" (fun input _ ctx -> state.Update.Value(ctx, unbox<'Key> input)))
-                | Guid -> yield addPlugs Update (routef "/%O" (fun input _ ctx -> state.Update.Value(ctx, unbox<'Key> input)))
+                | Bool ->
+                  siteMap.AddPath "/%b" "PATCH"
+                  yield addPlugs Update (routef "/%b" (fun input _ ctx -> state.Update.Value(ctx, unbox<'Key> input)))
+                | Char ->
+                  siteMap.AddPath "/%c" "PATCH"
+                  yield addPlugs Update (routef "/%c" (fun input _ ctx -> state.Update.Value(ctx, unbox<'Key> input)))
+                | String ->
+                  siteMap.AddPath "/%s" "PATCH"
+                  yield addPlugs Update (routef "/%s" (fun input _ ctx -> state.Update.Value(ctx, unbox<'Key> input)))
+                | Int32 ->
+                  siteMap.AddPath "/%i" "PATCH"
+                  yield addPlugs Update (routef "/%i" (fun input _ ctx -> state.Update.Value(ctx, unbox<'Key> input)))
+                | Int64 ->
+                  siteMap.AddPath "/%d" "PATCH"
+                  yield addPlugs Update (routef "/%d" (fun input _ ctx -> state.Update.Value(ctx, unbox<'Key> input)))
+                | Float ->
+                  siteMap.AddPath "/%f" "PATCH"
+                  yield addPlugs Update (routef "/%f" (fun input _ ctx -> state.Update.Value(ctx, unbox<'Key> input)))
+                | Guid ->
+                  siteMap.AddPath "/%O" "PATCH"
+                  yield addPlugs Update (routef "/%O" (fun input _ ctx -> state.Update.Value(ctx, unbox<'Key> input)))
           ]
           yield PUT >=> choose [
             if state.Update.IsSome then
@@ -140,16 +202,31 @@ module Controller =
               | None -> ()
               | Some k ->
                 match k with
-                | Bool -> yield addPlugs Update (routef "/%b" (fun input _ ctx -> state.Update.Value(ctx, unbox<'Key> input)))
-                | Char -> yield addPlugs Update (routef "/%c" (fun input _ ctx -> state.Update.Value(ctx, unbox<'Key> input)))
-                | String -> yield addPlugs Update (routef "/%s" (fun input _ ctx -> state.Update.Value(ctx, unbox<'Key> input)))
-                | Int32 -> yield addPlugs Update (routef "/%i" (fun input _ ctx -> state.Update.Value(ctx, unbox<'Key> input)))
-                | Int64 -> yield addPlugs Update (routef "/%d" (fun input _ ctx -> state.Update.Value(ctx, unbox<'Key> input)))
-                | Float -> yield addPlugs Update (routef "/%f" (fun input _ ctx -> state.Update.Value(ctx, unbox<'Key> input)))
-                | Guid -> yield addPlugs Update (routef "/%O" (fun input _ ctx -> state.Update.Value(ctx, unbox<'Key> input)))
+                | Bool ->
+                  siteMap.AddPath "/%b" "PUT"
+                  yield addPlugs Update (routef "/%b" (fun input _ ctx -> state.Update.Value(ctx, unbox<'Key> input)))
+                | Char ->
+                  siteMap.AddPath "/%c" "PUT"
+                  yield addPlugs Update (routef "/%c" (fun input _ ctx -> state.Update.Value(ctx, unbox<'Key> input)))
+                | String ->
+                  siteMap.AddPath "/%s" "PUT"
+                  yield addPlugs Update (routef "/%s" (fun input _ ctx -> state.Update.Value(ctx, unbox<'Key> input)))
+                | Int32 ->
+                  siteMap.AddPath "/%i" "PUT"
+                  yield addPlugs Update (routef "/%i" (fun input _ ctx -> state.Update.Value(ctx, unbox<'Key> input)))
+                | Int64 ->
+                  siteMap.AddPath "/%d" "PUT"
+                  yield addPlugs Update (routef "/%d" (fun input _ ctx -> state.Update.Value(ctx, unbox<'Key> input)))
+                | Float ->
+                  siteMap.AddPath "/%f" "PUT"
+                  yield addPlugs Update (routef "/%f" (fun input _ ctx -> state.Update.Value(ctx, unbox<'Key> input)))
+                | Guid ->
+                  siteMap.AddPath "/%O" "PUT"
+                  yield addPlugs Update (routef "/%O" (fun input _ ctx -> state.Update.Value(ctx, unbox<'Key> input)))
           ]
           yield DELETE >=> choose [
             if state.DeleteAll.IsSome then
+              siteMap.AddPath "/" "DELETE"
               yield addPlugs DeleteAll (route "" >=> (fun _ ctx -> ctx.Request.Path <- PathString(ctx.Request.Path.ToString() + "/"); state.DeleteAll.Value(ctx)))
               yield addPlugs DeleteAll (route "/" >=> (fun _ ctx -> state.DeleteAll.Value(ctx)))
             if state.Delete.IsSome then
@@ -157,15 +234,31 @@ module Controller =
               | None -> ()
               | Some k ->
                 match k with
-                | Bool -> yield addPlugs Delete (routef "/%b" (fun input _ ctx -> state.Delete.Value(ctx, unbox<'Key> input)))
-                | Char -> yield addPlugs Delete (routef "/%c" (fun input _ ctx -> state.Delete.Value(ctx, unbox<'Key> input)))
-                | String -> yield addPlugs Delete (routef "/%s" (fun input _ ctx -> state.Delete.Value(ctx, unbox<'Key> input)))
-                | Int32 -> yield addPlugs Delete (routef "/%i" (fun input _ ctx -> state.Delete.Value(ctx, unbox<'Key> input)))
-                | Int64 -> yield addPlugs Delete (routef "/%d" (fun input _ ctx -> state.Delete.Value(ctx, unbox<'Key> input)))
-                | Float -> yield addPlugs Delete (routef "/%f" (fun input _ ctx -> state.Delete.Value(ctx, unbox<'Key> input)))
-                | Guid -> yield addPlugs Delete (routef "/%O" (fun input _ ctx -> state.Delete.Value(ctx, unbox<'Key> input)))
+                | Bool ->
+                  siteMap.AddPath "/%b" "DELETE"
+                  yield addPlugs Delete (routef "/%b" (fun input _ ctx -> state.Delete.Value(ctx, unbox<'Key> input)))
+                | Char ->
+                  siteMap.AddPath "/%c" "DELETE"
+                  yield addPlugs Delete (routef "/%c" (fun input _ ctx -> state.Delete.Value(ctx, unbox<'Key> input)))
+                | String ->
+                  siteMap.AddPath "/%s" "DELETE"
+                  yield addPlugs Delete (routef "/%s" (fun input _ ctx -> state.Delete.Value(ctx, unbox<'Key> input)))
+                | Int32 ->
+                  siteMap.AddPath "/%i" "DELETE"
+                  yield addPlugs Delete (routef "/%i" (fun input _ ctx -> state.Delete.Value(ctx, unbox<'Key> input)))
+                | Int64 ->
+                  siteMap.AddPath "/%d" "DELETE"
+                  yield addPlugs Delete (routef "/%d" (fun input _ ctx -> state.Delete.Value(ctx, unbox<'Key> input)))
+                | Float ->
+                  siteMap.AddPath "/%f" "DELETE"
+                  yield addPlugs Delete (routef "/%f" (fun input _ ctx -> state.Delete.Value(ctx, unbox<'Key> input)))
+                | Guid ->
+                  siteMap.AddPath "/%O" "DELETE"
+                  yield addPlugs Delete (routef "/%O" (fun input _ ctx -> state.Delete.Value(ctx, unbox<'Key> input)))
           ]
-          if state.NotFoundHandler.IsSome then yield state.NotFoundHandler.Value
+          if state.NotFoundHandler.IsSome then
+            siteMap.NotFound ()
+            yield state.NotFoundHandler.Value
       ]
 
       let controllerWithErrorHandler nxt ctx : HttpFuncResult =
@@ -184,33 +277,52 @@ module Controller =
             | Some k ->
               match k with
               | Bool ->
+                let dummy = sCs (unbox<'Key> false)
+                siteMap.Forward ("/%b" + sPath) "" dummy
                 yield routef (PrintfFormat<bool -> obj, obj, obj, obj, bool>("/%b" + sPath)) (fun input -> subRoute ("/" + (string input) + sPath) (sCs (unbox<'Key> input)))
                 yield routef (PrintfFormat<bool -> string -> obj, obj, obj, obj, bool * string>("/%b" + sPath + "%s")) (fun (input, _) -> subRoute ("/" + (string input) + sPath) (sCs (unbox<'Key> input)))
               | Char ->
+                let dummy = sCs (unbox<'Key> ' ')
+                siteMap.Forward ("/%c" + sPath) "" dummy
                 yield routef (PrintfFormat<char -> obj, obj, obj, obj, char>("/%c" + sPath)) (fun input -> subRoute ("/" + (string input) + sPath) (sCs (unbox<'Key> input)))
                 yield routef (PrintfFormat<char -> string -> obj, obj, obj, obj, char * string>("/%c" + sPath + "%s")) (fun (input, _) -> subRoute ("/" + (string input) + sPath) (sCs (unbox<'Key> input)))
               | String ->
+                let dummy = sCs (unbox<'Key> "")
+                siteMap.Forward ("/%s" + sPath) "" dummy
                 yield routef (PrintfFormat<string -> obj, obj, obj, obj, string>("/%s" + sPath)) (fun input -> subRoute ("/" + (string input) + sPath) (sCs (unbox<'Key> input)))
                 yield routef (PrintfFormat<string -> string -> obj, obj, obj, obj, string * string>("/%s" + sPath + "%s")) (fun (input, _) -> subRoute ("/" + (string input) + sPath) (sCs (unbox<'Key> input)))
               | Int32 ->
+                let dummy = sCs (unbox<'Key> 0)
+                siteMap.Forward ("/%i" + sPath) "" dummy
                 yield routef (PrintfFormat<int -> obj, obj, obj, obj, int>("/%i" + sPath)) (fun input -> subRoute ("/" + (string input) + sPath) (sCs (unbox<'Key> input)))
                 yield routef (PrintfFormat<int -> string -> obj, obj, obj, obj, int * string>("/%i" + sPath + "%s")) (fun (input, _) -> subRoute ("/" + (string input) + sPath) (sCs (unbox<'Key> input)))
               | Int64 ->
+                let dummy = sCs (unbox<'Key> 0L)
+                siteMap.Forward ("/%d" + sPath) "" dummy
                 yield routef (PrintfFormat<int64 -> obj, obj, obj, obj, int64>("/%d" + sPath)) (fun input -> subRoute ("/" + (string input) + sPath) (sCs (unbox<'Key> input)))
                 yield routef (PrintfFormat<int64 -> string -> obj, obj, obj, obj, int64 * string>("/%d" + sPath + "%s")) (fun (input, _) -> subRoute ("/" + (string input) + sPath) (sCs (unbox<'Key> input)))
               | Float ->
+                let dummy = sCs (unbox<'Key> 0.)
+                siteMap.Forward ("/%f" + sPath) "" dummy
                 yield routef (PrintfFormat<float -> obj, obj, obj, obj, float>("/%f" + sPath)) (fun input -> subRoute ("/" + (string input) + sPath) (sCs (unbox<'Key> input)))
                 yield routef (PrintfFormat<float -> string -> obj, obj, obj, obj, float * string>("/%f" + sPath + "%s")) (fun (input, _) -> subRoute ("/" + (string input) + sPath) (sCs (unbox<'Key> input)))
               | Guid ->
+                let dummy = sCs (unbox<'Key> Guid.Empty)
+                siteMap.Forward ("/%O" + sPath) "" dummy
                 yield routef (PrintfFormat<obj -> obj, obj, obj, obj, obj>("/%O" + sPath)) (fun input -> subRoute ("/" + (string input) + sPath) (sCs (unbox<'Key> input)))
                 yield routef (PrintfFormat<obj -> string -> obj, obj, obj, obj, obj * string>("/%O" + sPath + "%s")) (fun (input, _) -> subRoute ("/" + (string input) + sPath) (sCs (unbox<'Key> input)))
           yield controllerWithErrorHandler
         ]
 
-      match state.Version with
-      | None -> controllerWithSubs
-      | Some v ->
-        requireHeader "x-controller-version" (v.ToString()) >=> controllerWithSubs
+      let res =
+        match state.Version with
+        | None -> controllerWithSubs
+        | Some v ->
+          siteMap.Version <- Some v
+          requireHeader "x-controller-version" (v.ToString()) >=> controllerWithSubs
+      siteMap.SetKey res
+      SiteMap.add siteMap
+      res
 
     ///Operation that should render (or return in case of API controllers) list of data
     [<CustomOperation("index")>]

--- a/src/Saturn/Diagnostics.fs
+++ b/src/Saturn/Diagnostics.fs
@@ -2,7 +2,7 @@ namespace Saturn
 open System.IO
 
 module SiteMap =
-    let mutable private isDebug = true //Somehow detect if Saturn is used by application compiled in debug or release
+    let mutable internal isDebug = true //Somehow detect if Saturn is used by application compiled in debug or release
 
     type internal PathRegistrationEvent =
         | Path of path: string * verb: string

--- a/src/Saturn/Diagnostics.fs
+++ b/src/Saturn/Diagnostics.fs
@@ -1,0 +1,68 @@
+namespace Saturn
+open System.IO
+
+module SiteMap =
+    let mutable private isDebug = true //Somehow detect if Saturn is used by application compiled in debug or release
+
+    type internal PathRegistrationEvent =
+        | Path of path: string * verb: string
+        | Forward of path: string * verb: string * key: obj
+        | NotFound
+
+
+
+    type HandlerMap () =
+        let paths = ResizeArray<PathRegistrationEvent>()
+        let mutable key : obj = null
+        member val Version : int option = None with get, set
+
+        member __.AddPath p v = paths.Add(Path(p,v))
+
+        member __.Forward p v k = paths.Add(Forward(p,v,k))
+
+        member __.NotFound () = paths.Add(NotFound)
+
+        member __.SetKey k = key <- k
+
+        member __.GetKey () = key
+
+        member internal __.GetPaths () = paths
+
+        member this.CollectPaths prefix version (state : HandlerMap seq) =
+            let ver =
+                match this.Version with
+                | None -> version
+                | Some v -> Some v
+            paths |> Seq.collect (function
+                | Forward(p,v,k) ->
+                    match state |> Seq.tryFind (fun s -> s.GetKey () = k) with
+                    | Some res ->
+                        res.CollectPaths (prefix + p) ver state
+                    | None ->
+                        ((prefix + p), v, ver)
+                        |> Seq.singleton
+                | Path(p,v) ->
+                    ((prefix + p), v, ver)
+                    |> Seq.singleton
+                | NotFound ->
+                    (prefix, "NotFoundHandler", ver)
+                    |> Seq.singleton
+            )
+    let private state = ResizeArray<HandlerMap> ()
+
+    let add hm = state.Add(hm)
+    let generate () =
+        let s = state |> Seq.last
+        let z = s.CollectPaths "" None state
+        let typ = typeof<HandlerMap>
+        let asm = typ.Assembly.Location
+        let p = Path.Combine(Path.GetDirectoryName(asm), "site.map")
+        let cnt =
+            z
+            |> Seq.map (fun (a,b,c) ->
+                let c = (c |> function Some v -> v.ToString() | None -> "")
+                sprintf "%s, %s, %s" a b c
+            )
+            |> String.concat "\n"
+        File.WriteAllText(p, cnt)
+

--- a/src/Saturn/Saturn.fsproj
+++ b/src/Saturn/Saturn.fsproj
@@ -1,16 +1,14 @@
-<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>Saturn</AssemblyName>
     <OutputType>Library</OutputType>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <DebugType>portable</DebugType>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="Utils.fs" />
     <Compile Include="Common.fs" />
+    <Compile Include="Diagnostics.fs" />
     <Compile Include="CORS.fs" />
     <Compile Include="Pipelines.fs" />
     <Compile Include="Router.fs" />


### PR DESCRIPTION
This PR is adding ability to generate on application startup file containing information about routing of the application. This enables creating really interesting set of developer tools such as command line and GUI clients (like the ones shown by MSFT for ASP.NET during Build), Swagger generator, automatic testing tools etc.

Known limitations:
* It supports only routing defined by `scope` and `controller` CE - i have no way to introspect webparts created by lower level Giraffe combinators that can also include routing.
* The code is super hacky, however it should be executed (mostly) at application startup. I probably should investigate disabling mechanism that collects routing data after server has started.