### PR TITLE
Typed controller output

### DIFF
--- a/sample/Controller.Sample/Controller.Sample.fs
+++ b/sample/Controller.Sample/Controller.Sample.fs
@@ -3,6 +3,8 @@ module Controller.Sample
 open Saturn
 open Giraffe.Core
 open Giraffe.ResponseWriters
+open Giraffe
+open System
 
 let commentController userId = controller {
     index (fun ctx -> (sprintf "Comment Index handler for user %i" userId ) |> Controller.text ctx)
@@ -37,6 +39,26 @@ let userController = controller {
     error_handler (fun ctx ex -> sprintf "Error handler no version - %s" ex.Message |> Controller.text ctx)
 }
 
+type Response = {
+    a: string
+    b: string
+}
+
+type DifferentResponse = {
+    c: int
+    d: DateTime
+}
+
+let typedController = controller {
+    index (fun _ -> task {
+        return {a = "hello"; b = "world"}
+    })
+
+    add (fun _ -> task {
+        return {c = 123; d = DateTime.Now}
+    })
+}
+
 let otherRouter = scope {
     get "/dsa" (text "")
     getf "/dsa/%s" (text)
@@ -47,6 +69,7 @@ let otherRouter = scope {
 let topRouter = scope {
     forward "/users" userControllerVersion1
     forward "/users" userController
+    forward "/typed" typedController
     forwardf "/%s/%s/abc" (fun (a : string * string) -> otherRouter)
 }
 

--- a/src/Saturn/Controller.fs
+++ b/src/Saturn/Controller.fs
@@ -47,7 +47,7 @@ module Controller =
     | Float
     | Guid
 
-  let inline response<'a> ctx (input : System.Threading.Tasks.Task<'a>) =
+  let inline response<'a> ctx (input : Task<'a>) =
       task {
         let! i = input
         return! Controller.response ctx i
@@ -55,13 +55,8 @@ module Controller =
 
   type ControllerBuilder<'Key, 'IndexOutput, 'ShowOutput, 'AddOutput, 'EditOutput, 'CreateOutput, 'UpdateOutput, 'DeleteOutput, 'DeleteAllOutput> internal () =
 
-
-
-
     member __.Yield(_) : ControllerState<'Key, 'IndexOutput, 'ShowOutput, 'AddOutput, 'EditOutput, 'CreateOutput, 'UpdateOutput, 'DeleteOutput, 'DeleteAllOutput> =
       { Index = None; Show = None; Add = None; Edit = None; Create = None; Update = None; Delete = None; DeleteAll = None; NotFoundHandler = None; Version = None; SubControllers = []; Plugs = Map.empty<_,_>; ErrorHandler = (fun _ ex -> raise ex) }
-
-
 
     ///Operation that should render (or return in case of API controllers) list of data
     [<CustomOperation("index")>]
@@ -134,15 +129,39 @@ module Controller =
             state.Plugs.Add(action,[handler])
         {state with Plugs = newplugs}
 
-
       if actions |> List.contains All then
         [Index; Show; Add; Edit; Create; Update; Delete] |> List.fold (fun acc e -> addPlug acc e handler) state
       else
         actions |> List.fold (fun acc e -> addPlug acc e handler) state
 
-    member __.Run (state: ControllerState<'Key, 'IndexOutput, 'ShowOutput, 'AddOutput, 'EditOutput, 'CreateOutput, 'UpdateOutput, 'DeleteOutput, 'DeleteAllOutput>) : HttpHandler =
+    member private __.AddHandler<'Output> state action (handler: HttpContext -> Task<'Output>) path =
+      let route = route path
+
+      let handler =
+        match typeof<'Output> with
+        | k when k = typeof<HttpContext option> -> fun _ ctx -> handler ctx |> unbox<HttpFuncResult>
+        | _ -> fun _ ctx -> handler ctx |> response<'Output> ctx
+
+      match state.Plugs.TryFind action with
+      | Some acts -> (succeed |> List.foldBack (fun e acc -> acc >=> e) acts) >=> route >=> handler
+      | None -> route >=> handler
+
+    member private __.AddKeyHandler<'Output> state action (handler: HttpContext -> 'Key -> Task<'Output>) path =
+      let route = routef (PrintfFormat<_,_,_,_,'Key> path)
+
+      let handler =
+        match typeof<'Output> with
+        | k when k = typeof<HttpContext option> -> fun input _ ctx -> handler ctx (unbox<'Key> input) |> unbox<HttpFuncResult>
+        | _ -> fun input _ ctx -> handler ctx (unbox<'Key> input) |> response<'Output> ctx
+
+      match state.Plugs.TryFind action with
+      | Some acts -> (succeed |> List.foldBack (fun e acc -> acc >=> e) acts) >=> route handler
+      | None -> route handler
+
+    member this.Run (state: ControllerState<'Key, 'IndexOutput, 'ShowOutput, 'AddOutput, 'EditOutput, 'CreateOutput, 'UpdateOutput, 'DeleteOutput, 'DeleteAllOutput>) : HttpHandler =
       let siteMap = HandlerMap()
-      let typ =
+      let addToSiteMap v p = siteMap.AddPath p v
+      let keyFormat =
         match state with
         | { Show = None; Edit = None; Update = None; Delete = None; SubControllers = [] } -> None
         | _ ->
@@ -156,298 +175,91 @@ module Controller =
           | k when k = typeof<System.Guid> -> Guid
           | k -> failwithf
                   "Type %A is not a supported type for controller<'T>. Supported types include bool, char, float, guid int32, int64, and string" k
+          |> function
+              | Bool -> "/%b"
+              | Char -> "/%c"
+              | String -> "/%s"
+              | Int32 -> "/%i"
+              | Int64 -> "/%d"
+              | Float -> "/%f"
+              | Guid -> "/%O"
           |> Some
-
-      let addPlugs action handler =
-        match state.Plugs.TryFind action with
-        | Some acts -> (succeed |> List.foldBack (fun e acc -> acc >=> e) acts) >=> handler
-        | None -> handler
 
       let initialController =
         choose [
           yield GET >=> choose [
-            if state.Add.IsSome then
-              siteMap.AddPath "/add" "GET"
-              match typeof<'AddOutput> with
-              | k when k = typeof<HttpContext option> -> yield addPlugs Add (route "/add" >=> (fun _ ctx -> state.Add.Value(ctx) |> unbox<HttpFuncResult> ))
-              | _ -> yield addPlugs Add (route "/add" >=> (fun _ ctx -> state.Add.Value(ctx) |> response<_> ctx))
+            let addToSiteMap = addToSiteMap "GET"
 
-            if state.Edit.IsSome then
-              match typ with
-              | None -> ()
-              | Some k ->
-                match k with
-                | Bool ->
-                  siteMap.AddPath "/%b/edit" "GET"
-                  match typeof<'EditOutput> with
-                  | k when k = typeof<HttpContext option> -> yield addPlugs Edit (routef "/%b/edit" (fun input _ ctx -> state.Edit.Value ctx (unbox<'Key> input) |> unbox<HttpFuncResult>))
-                  | _ -> yield addPlugs Edit (routef "/%b/edit" (fun input _ ctx -> state.Edit.Value ctx (unbox<'Key> input) |> response<_> ctx))
-                | Char ->
-                  siteMap.AddPath "/%c/edit" "GET"
-                  match typeof<'EditOutput> with
-                  | k when k = typeof<HttpContext option> -> yield addPlugs Edit (routef "/%c/edit" (fun input _ ctx -> state.Edit.Value ctx (unbox<'Key> input) |> unbox<HttpFuncResult>))
-                  | _ -> yield addPlugs Edit (routef "/%c/edit" (fun input _ ctx -> state.Edit.Value ctx (unbox<'Key> input) |> response<_> ctx))
-                | String ->
-                  siteMap.AddPath "/%s/edit" "GET"
-                  match typeof<'EditOutput> with
-                  | k when k = typeof<HttpContext option> -> yield addPlugs Edit (routef "/%s/edit" (fun input _ ctx -> state.Edit.Value ctx (unbox<'Key> input) |> unbox<HttpFuncResult>))
-                  | _ -> yield addPlugs Edit (routef "/%s/edit" (fun input _ ctx -> state.Edit.Value ctx (unbox<'Key> input) |> response<_> ctx))
-                | Int32 ->
-                  siteMap.AddPath "/%i/edit" "GET"
-                  match typeof<'EditOutput> with
-                  | k when k = typeof<HttpContext option> -> yield addPlugs Edit (routef "/%i/edit" (fun input _ ctx -> state.Edit.Value ctx (unbox<'Key> input) |> unbox<HttpFuncResult>))
-                  | _ -> yield addPlugs Edit (routef "/%i/edit" (fun input _ ctx -> state.Edit.Value ctx (unbox<'Key> input) |> response<_> ctx))
-                | Int64 ->
-                  siteMap.AddPath "/%d/edit" "GET"
-                  match typeof<'EditOutput> with
-                  | k when k = typeof<HttpContext option> -> yield addPlugs Edit (routef "/%d/edit" (fun input _ ctx -> state.Edit.Value ctx (unbox<'Key> input) |> unbox<HttpFuncResult>))
-                  | _ -> yield addPlugs Edit (routef "/%d/edit" (fun input _ ctx -> state.Edit.Value ctx (unbox<'Key> input) |> response<_> ctx))
-                | Float ->
-                  siteMap.AddPath "/%f/edit" "GET"
-                  match typeof<'EditOutput> with
-                  | k when k = typeof<HttpContext option> -> yield addPlugs Edit (routef "/%f/edit" (fun input _ ctx -> state.Edit.Value ctx (unbox<'Key> input) |> unbox<HttpFuncResult>))
-                  | _ -> yield addPlugs Edit (routef "/%f/edit" (fun input _ ctx -> state.Edit.Value ctx (unbox<'Key> input) |> response<_> ctx))
-                | Guid ->
-                  siteMap.AddPath "/%O/edit" "GET"
-                  match typeof<'EditOutput> with
-                  | k when k = typeof<HttpContext option> -> yield addPlugs Edit (routef "/%O/edit" (fun input _ ctx -> state.Edit.Value ctx (unbox<'Key> input) |> unbox<HttpFuncResult>))
-                  | _ -> yield addPlugs Edit (routef "/%O/edit" (fun input _ ctx -> state.Edit.Value ctx (unbox<'Key> input) |> response<_> ctx))
-            if state.Show.IsSome then
-              match typ with
-              | None -> ()
-              | Some k ->
-                match k with
-                | Bool ->
-                  siteMap.AddPath "/%b" "GET"
-                  match typeof<'ShowOutput> with
-                  | k when k = typeof<HttpContext option> -> yield addPlugs Show (routef "/%b" (fun input _ ctx ->  state.Show.Value ctx (unbox<'Key> input) |> unbox<HttpFuncResult>))
-                  | _ -> yield addPlugs Show (routef "/%b" (fun input _ ctx -> state.Show.Value ctx (unbox<'Key> input) |> response<_> ctx))
-                | Char ->
-                  siteMap.AddPath "/%c" "GET"
-                  match typeof<'ShowOutput> with
-                  | k when k = typeof<HttpContext option> -> yield addPlugs Show (routef "/%c" (fun input _ ctx ->  state.Show.Value ctx (unbox<'Key> input) |> unbox<HttpFuncResult>))
-                  | _ -> yield addPlugs Show (routef "/%c" (fun input _ ctx -> state.Show.Value ctx (unbox<'Key> input) |> response<_> ctx))
-                | String ->
-                  siteMap.AddPath "/%s" "GET"
-                  match typeof<'ShowOutput> with
-                  | k when k = typeof<HttpContext option> -> yield addPlugs Show (routef "/%s" (fun input _ ctx ->  state.Show.Value ctx (unbox<'Key> input) |> unbox<HttpFuncResult>))
-                  | _ -> yield addPlugs Show (routef "/%s" (fun input _ ctx -> state.Show.Value ctx (unbox<'Key> input) |> response<_> ctx))
-                | Int32 ->
-                  siteMap.AddPath "/%i" "GET"
-                  match typeof<'ShowOutput> with
-                  | k when k = typeof<HttpContext option> -> yield addPlugs Show (routef "/%i" (fun input _ ctx ->  state.Show.Value ctx (unbox<'Key> input) |> unbox<HttpFuncResult>))
-                  | _ -> yield addPlugs Show (routef "/%i" (fun input _ ctx -> state.Show.Value ctx (unbox<'Key> input) |> response<_> ctx))
-                | Int64 ->
-                  siteMap.AddPath "/%d" "GET"
-                  match typeof<'ShowOutput> with
-                  | k when k = typeof<HttpContext option> -> yield addPlugs Show (routef "/%d" (fun input _ ctx ->  state.Show.Value ctx (unbox<'Key> input) |> unbox<HttpFuncResult>))
-                  | _ -> yield addPlugs Show (routef "/%d" (fun input _ ctx -> state.Show.Value ctx (unbox<'Key> input) |> response<_> ctx))
-                | Float ->
-                  siteMap.AddPath "/%f" "GET"
-                  match typeof<'ShowOutput> with
-                  | k when k = typeof<HttpContext option> -> yield addPlugs Show (routef "/%f" (fun input _ ctx ->  state.Show.Value ctx (unbox<'Key> input) |> unbox<HttpFuncResult>))
-                  | _ -> yield addPlugs Show (routef "/%f" (fun input _ ctx -> state.Show.Value ctx (unbox<'Key> input) |> response<_> ctx))
-                | Guid ->
-                  siteMap.AddPath "/%O" "GET"
-                  match typeof<'ShowOutput> with
-                  | k when k = typeof<HttpContext option> -> yield addPlugs Show (routef "/%O" (fun input _ ctx ->  state.Show.Value ctx (unbox<'Key> input) |> unbox<HttpFuncResult>))
-                  | _ -> yield addPlugs Show (routef "/%O" (fun input _ ctx -> state.Show.Value ctx (unbox<'Key> input) |> response<_> ctx))
+            if state.Add.IsSome then
+              let path = "/add"
+              addToSiteMap path
+              yield this.AddHandler state Add state.Add.Value path
             if state.Index.IsSome then
-              siteMap.AddPath "/" "GET"
-              match typeof<'IndexOutput> with
-              | k when k = typeof<HttpContext option> ->
-                yield addPlugs Index (route "" >=> (fun _ ctx -> ctx.Request.Path <- PathString(ctx.Request.Path.ToString() + "/"); state.Index.Value(ctx) |> unbox<HttpFuncResult>))
-                yield addPlugs Index (route "/" >=> (fun _ ctx -> state.Index.Value(ctx) |> unbox<HttpFuncResult>))
-              | _ ->
-                yield addPlugs Index (route "" >=> (fun _ ctx -> ctx.Request.Path <- PathString(ctx.Request.Path.ToString() + "/"); state.Index.Value(ctx) |> response<_> ctx))
-                yield addPlugs Index (route "/" >=> (fun _ ctx -> state.Index.Value(ctx) |> response<_> ctx))
+              let path = "/"
+              let handler (ctx: HttpContext) = ctx.Request.Path <- PathString(ctx.Request.Path.ToString() + "/"); state.Index.Value(ctx)
+              addToSiteMap path
+              yield this.AddHandler state Index handler ""
+              yield this.AddHandler state Index handler path
+
+            if keyFormat.IsSome then
+              if state.Edit.IsSome then
+                let path = keyFormat.Value + "/edit"
+                addToSiteMap path
+                yield this.AddKeyHandler state Edit state.Edit.Value path
+              if state.Show.IsSome then
+                let path = keyFormat.Value
+                addToSiteMap path
+                yield this.AddKeyHandler state Show state.Show.Value path
           ]
           yield POST >=> choose [
-            if state.Create.IsSome then
-              siteMap.AddPath "/" "POST"
-              match typeof<'CreateOutput> with
-              | k when k = typeof<HttpContext option> ->
-                yield addPlugs Create (route "" >=> (fun _ ctx -> ctx.Request.Path <- PathString(ctx.Request.Path.ToString() + "/"); state.Create.Value(ctx) |> unbox<HttpFuncResult>))
-                yield addPlugs Create (route "/" >=> (fun _ ctx -> state.Create.Value(ctx) |> unbox<HttpFuncResult>))
-              | _ ->
-                yield addPlugs Create (route "" >=> (fun _ ctx -> ctx.Request.Path <- PathString(ctx.Request.Path.ToString() + "/"); state.Create.Value(ctx) |> response<_> ctx))
-                yield addPlugs Create (route "/" >=> (fun _ ctx -> state.Create.Value(ctx) |> response<_> ctx))
+            let addToSiteMap = addToSiteMap "POST"
 
-            if state.Update.IsSome then
-              match typ with
-              | None -> ()
-              | Some k ->
-                match k with
-                | Bool ->
-                  siteMap.AddPath "/%b" "POST"
-                  match typeof<'UpdateOutput> with
-                  | k when k = typeof<HttpContext option> -> yield addPlugs Update (routef "/%b" (fun input _ ctx -> state.Update.Value ctx (unbox<'Key> input) |> unbox<HttpFuncResult>))
-                  | _ ->  yield addPlugs Update (routef "/%b" (fun input _ ctx -> state.Update.Value ctx (unbox<'Key> input) |> response<_> ctx))
-                | Char ->
-                  siteMap.AddPath "/%c" "POST"
-                  match typeof<'UpdateOutput> with
-                  | k when k = typeof<HttpContext option> -> yield addPlugs Update (routef "/%s" (fun input _ ctx -> state.Update.Value ctx (unbox<'Key> input) |> unbox<HttpFuncResult>))
-                  | _ ->  yield addPlugs Update (routef "/%s" (fun input _ ctx -> state.Update.Value ctx (unbox<'Key> input) |> response<_> ctx))
-                | String ->
-                  siteMap.AddPath "/%s" "POST"
-                  match typeof<'UpdateOutput> with
-                  | k when k = typeof<HttpContext option> -> yield addPlugs Update (routef "/%s" (fun input _ ctx -> state.Update.Value ctx (unbox<'Key> input) |> unbox<HttpFuncResult>))
-                  | _ ->  yield addPlugs Update (routef "/%s" (fun input _ ctx -> state.Update.Value ctx (unbox<'Key> input) |> response<_> ctx))
-                | Int32 ->
-                  siteMap.AddPath "/%i" "POST"
-                  match typeof<'UpdateOutput> with
-                  | k when k = typeof<HttpContext option> -> yield addPlugs Update (routef "/%i" (fun input _ ctx -> state.Update.Value ctx (unbox<'Key> input) |> unbox<HttpFuncResult>))
-                  | _ ->  yield addPlugs Update (routef "/%i" (fun input _ ctx -> state.Update.Value ctx (unbox<'Key> input) |> response<_> ctx))
-                | Int64 ->
-                  siteMap.AddPath "/%d" "POST"
-                  match typeof<'UpdateOutput> with
-                  | k when k = typeof<HttpContext option> -> yield addPlugs Update (routef "/%d" (fun input _ ctx -> state.Update.Value ctx (unbox<'Key> input) |> unbox<HttpFuncResult>))
-                  | _ ->  yield addPlugs Update (routef "/%d" (fun input _ ctx -> state.Update.Value ctx (unbox<'Key> input) |> response<_> ctx))
-                | Float ->
-                  siteMap.AddPath "/%f" "POST"
-                  match typeof<'UpdateOutput> with
-                  | k when k = typeof<HttpContext option> -> yield addPlugs Update (routef "/%f" (fun input _ ctx -> state.Update.Value ctx (unbox<'Key> input) |> unbox<HttpFuncResult>))
-                  | _ ->  yield addPlugs Update (routef "/%f" (fun input _ ctx -> state.Update.Value ctx (unbox<'Key> input) |> response<_> ctx))
-                | Guid ->
-                  siteMap.AddPath "/%O" "POST"
-                  match typeof<'UpdateOutput> with
-                  | k when k = typeof<HttpContext option> -> yield addPlugs Update (routef "/%O" (fun input _ ctx -> state.Update.Value ctx (unbox<'Key> input) |> unbox<HttpFuncResult>))
-                  | _ ->  yield addPlugs Update (routef "/%O" (fun input _ ctx -> state.Update.Value ctx (unbox<'Key> input) |> response<_> ctx))
+            if state.Create.IsSome then
+              let path = "/"
+              let handler (ctx: HttpContext) = ctx.Request.Path <- PathString(ctx.Request.Path.ToString() + "/"); state.Create.Value(ctx)
+              addToSiteMap path
+              yield this.AddHandler state Create handler ""
+              yield this.AddHandler state Create handler path
+
+            if keyFormat.IsSome then
+              if state.Update.IsSome then
+                let path = keyFormat.Value
+                addToSiteMap path
+                yield this.AddKeyHandler state Update state.Update.Value path
           ]
           yield PATCH >=> choose [
-            if state.Update.IsSome then
-              match typ with
-              | None -> ()
-              | Some k ->
-                match k with
-                | Bool ->
-                  siteMap.AddPath "/%b" "POST"
-                  match typeof<'UpdateOutput> with
-                  | k when k = typeof<HttpContext option> -> yield addPlugs Update (routef "/%b" (fun input _ ctx -> state.Update.Value ctx (unbox<'Key> input) |> unbox<HttpFuncResult>))
-                  | _ ->  yield addPlugs Update (routef "/%b" (fun input _ ctx -> state.Update.Value ctx (unbox<'Key> input) |> response<_> ctx))
-                | Char ->
-                  siteMap.AddPath "/%c" "POST"
-                  match typeof<'UpdateOutput> with
-                  | k when k = typeof<HttpContext option> -> yield addPlugs Update (routef "/%s" (fun input _ ctx -> state.Update.Value ctx (unbox<'Key> input) |> unbox<HttpFuncResult>))
-                  | _ ->  yield addPlugs Update (routef "/%s" (fun input _ ctx -> state.Update.Value ctx (unbox<'Key> input) |> response<_> ctx))
-                | String ->
-                  siteMap.AddPath "/%s" "POST"
-                  match typeof<'UpdateOutput> with
-                  | k when k = typeof<HttpContext option> -> yield addPlugs Update (routef "/%s" (fun input _ ctx -> state.Update.Value ctx (unbox<'Key> input) |> unbox<HttpFuncResult>))
-                  | _ ->  yield addPlugs Update (routef "/%s" (fun input _ ctx -> state.Update.Value ctx (unbox<'Key> input) |> response<_> ctx))
-                | Int32 ->
-                  siteMap.AddPath "/%i" "POST"
-                  match typeof<'UpdateOutput> with
-                  | k when k = typeof<HttpContext option> -> yield addPlugs Update (routef "/%i" (fun input _ ctx -> state.Update.Value ctx (unbox<'Key> input) |> unbox<HttpFuncResult>))
-                  | _ ->  yield addPlugs Update (routef "/%i" (fun input _ ctx -> state.Update.Value ctx (unbox<'Key> input) |> response<_> ctx))
-                | Int64 ->
-                  siteMap.AddPath "/%d" "POST"
-                  match typeof<'UpdateOutput> with
-                  | k when k = typeof<HttpContext option> -> yield addPlugs Update (routef "/%d" (fun input _ ctx -> state.Update.Value ctx (unbox<'Key> input) |> unbox<HttpFuncResult>))
-                  | _ ->  yield addPlugs Update (routef "/%d" (fun input _ ctx -> state.Update.Value ctx (unbox<'Key> input) |> response<_> ctx))
-                | Float ->
-                  siteMap.AddPath "/%f" "POST"
-                  match typeof<'UpdateOutput> with
-                  | k when k = typeof<HttpContext option> -> yield addPlugs Update (routef "/%f" (fun input _ ctx -> state.Update.Value ctx (unbox<'Key> input) |> unbox<HttpFuncResult>))
-                  | _ ->  yield addPlugs Update (routef "/%f" (fun input _ ctx -> state.Update.Value ctx (unbox<'Key> input) |> response<_> ctx))
-                | Guid ->
-                  siteMap.AddPath "/%O" "POST"
-                  match typeof<'UpdateOutput> with
-                  | k when k = typeof<HttpContext option> -> yield addPlugs Update (routef "/%O" (fun input _ ctx -> state.Update.Value ctx (unbox<'Key> input) |> unbox<HttpFuncResult>))
-                  | _ ->  yield addPlugs Update (routef "/%O" (fun input _ ctx -> state.Update.Value ctx (unbox<'Key> input) |> response<_> ctx))
+            let addToSiteMap = addToSiteMap "PATCH"
+
+            if keyFormat.IsSome then
+              if state.Update.IsSome then
+                let path = keyFormat.Value
+                addToSiteMap path
+                yield this.AddKeyHandler state Update state.Update.Value path
           ]
           yield PUT >=> choose [
-            if state.Update.IsSome then
-              match typ with
-              | None -> ()
-              | Some k ->
-                match k with
-                | Bool ->
-                  siteMap.AddPath "/%b" "POST"
-                  match typeof<'UpdateOutput> with
-                  | k when k = typeof<HttpContext option> -> yield addPlugs Update (routef "/%b" (fun input _ ctx -> state.Update.Value ctx (unbox<'Key> input) |> unbox<HttpFuncResult>))
-                  | _ ->  yield addPlugs Update (routef "/%b" (fun input _ ctx -> state.Update.Value ctx (unbox<'Key> input) |> response<_> ctx))
-                | Char ->
-                  siteMap.AddPath "/%c" "POST"
-                  match typeof<'UpdateOutput> with
-                  | k when k = typeof<HttpContext option> -> yield addPlugs Update (routef "/%s" (fun input _ ctx -> state.Update.Value ctx (unbox<'Key> input) |> unbox<HttpFuncResult>))
-                  | _ ->  yield addPlugs Update (routef "/%s" (fun input _ ctx -> state.Update.Value ctx (unbox<'Key> input) |> response<_> ctx))
-                | String ->
-                  siteMap.AddPath "/%s" "POST"
-                  match typeof<'UpdateOutput> with
-                  | k when k = typeof<HttpContext option> -> yield addPlugs Update (routef "/%s" (fun input _ ctx -> state.Update.Value ctx (unbox<'Key> input) |> unbox<HttpFuncResult>))
-                  | _ ->  yield addPlugs Update (routef "/%s" (fun input _ ctx -> state.Update.Value ctx (unbox<'Key> input) |> response<_> ctx))
-                | Int32 ->
-                  siteMap.AddPath "/%i" "POST"
-                  match typeof<'UpdateOutput> with
-                  | k when k = typeof<HttpContext option> -> yield addPlugs Update (routef "/%i" (fun input _ ctx -> state.Update.Value ctx (unbox<'Key> input) |> unbox<HttpFuncResult>))
-                  | _ ->  yield addPlugs Update (routef "/%i" (fun input _ ctx -> state.Update.Value ctx (unbox<'Key> input) |> response<_> ctx))
-                | Int64 ->
-                  siteMap.AddPath "/%d" "POST"
-                  match typeof<'UpdateOutput> with
-                  | k when k = typeof<HttpContext option> -> yield addPlugs Update (routef "/%d" (fun input _ ctx -> state.Update.Value ctx (unbox<'Key> input) |> unbox<HttpFuncResult>))
-                  | _ ->  yield addPlugs Update (routef "/%d" (fun input _ ctx -> state.Update.Value ctx (unbox<'Key> input) |> response<_> ctx))
-                | Float ->
-                  siteMap.AddPath "/%f" "POST"
-                  match typeof<'UpdateOutput> with
-                  | k when k = typeof<HttpContext option> -> yield addPlugs Update (routef "/%f" (fun input _ ctx -> state.Update.Value ctx (unbox<'Key> input) |> unbox<HttpFuncResult>))
-                  | _ ->  yield addPlugs Update (routef "/%f" (fun input _ ctx -> state.Update.Value ctx (unbox<'Key> input) |> response<_> ctx))
-                | Guid ->
-                  siteMap.AddPath "/%O" "POST"
-                  match typeof<'UpdateOutput> with
-                  | k when k = typeof<HttpContext option> -> yield addPlugs Update (routef "/%O" (fun input _ ctx -> state.Update.Value ctx (unbox<'Key> input) |> unbox<HttpFuncResult>))
-                  | _ ->  yield addPlugs Update (routef "/%O" (fun input _ ctx -> state.Update.Value ctx (unbox<'Key> input) |> response<_> ctx))
+            let addToSiteMap = addToSiteMap "PUT"
+
+            if keyFormat.IsSome then
+              if state.Update.IsSome then
+                let path = keyFormat.Value
+                addToSiteMap path
+                yield this.AddKeyHandler state Update state.Update.Value path
           ]
           yield DELETE >=> choose [
+            let addToSiteMap = addToSiteMap "DELETE"
+
             if state.DeleteAll.IsSome then
-              siteMap.AddPath "/" "DELETE"
-              match typeof<'DeleteAllOutput> with
-              | k when k = typeof<HttpContext option> ->
-                yield addPlugs DeleteAll (route "" >=> (fun _ ctx -> ctx.Request.Path <- PathString(ctx.Request.Path.ToString() + "/"); state.DeleteAll.Value(ctx) |> unbox<HttpFuncResult>))
-                yield addPlugs DeleteAll (route "/" >=> (fun _ ctx -> state.DeleteAll.Value(ctx) |> unbox<HttpFuncResult>))
-              | _ ->
-                yield addPlugs DeleteAll (route "" >=> (fun _ ctx -> ctx.Request.Path <- PathString(ctx.Request.Path.ToString() + "/"); state.DeleteAll.Value(ctx) |> response<_> ctx))
-                yield addPlugs DeleteAll (route "/" >=> (fun _ ctx -> state.DeleteAll.Value(ctx) |> response<_> ctx))
-            if state.Delete.IsSome then
-              match typ with
-              | None -> ()
-              | Some k ->
-                match k with
-                | Bool ->
-                  siteMap.AddPath "/%b" "DELETE"
-                  match typeof<'DeleteOutput> with
-                  | k when k = typeof<HttpContext option> -> yield addPlugs Delete (routef "/%b" (fun input _ ctx -> state.Delete.Value ctx (unbox<'Key> input) |> unbox<HttpFuncResult>))
-                  | _ -> yield addPlugs Delete (routef "/%b" (fun input _ ctx -> state.Delete.Value ctx (unbox<'Key> input) |> response<_> ctx))
-                | Char ->
-                  siteMap.AddPath "/%c" "DELETE"
-                  match typeof<'DeleteOutput> with
-                  | k when k = typeof<HttpContext option> -> yield addPlugs Delete (routef "/%c" (fun input _ ctx -> state.Delete.Value ctx (unbox<'Key> input) |> unbox<HttpFuncResult>))
-                  | _ -> yield addPlugs Delete (routef "/%c" (fun input _ ctx -> state.Delete.Value ctx (unbox<'Key> input) |> response<_> ctx))
-                | String ->
-                  siteMap.AddPath "/%s" "DELETE"
-                  match typeof<'DeleteOutput> with
-                  | k when k = typeof<HttpContext option> -> yield addPlugs Delete (routef "/%s" (fun input _ ctx -> state.Delete.Value ctx (unbox<'Key> input) |> unbox<HttpFuncResult>))
-                  | _ -> yield addPlugs Delete (routef "/%s" (fun input _ ctx -> state.Delete.Value ctx (unbox<'Key> input) |> response<_> ctx))
-                | Int32 ->
-                  siteMap.AddPath "/%i" "DELETE"
-                  match typeof<'DeleteOutput> with
-                  | k when k = typeof<HttpContext option> -> yield addPlugs Delete (routef "/%i" (fun input _ ctx -> state.Delete.Value ctx (unbox<'Key> input) |> unbox<HttpFuncResult>))
-                  | _ -> yield addPlugs Delete (routef "/%i" (fun input _ ctx -> state.Delete.Value ctx (unbox<'Key> input) |> response<_> ctx))
-                | Int64 ->
-                  siteMap.AddPath "/%d" "DELETE"
-                  match typeof<'DeleteOutput> with
-                  | k when k = typeof<HttpContext option> -> yield addPlugs Delete (routef "/%d" (fun input _ ctx -> state.Delete.Value ctx (unbox<'Key> input) |> unbox<HttpFuncResult>))
-                  | _ -> yield addPlugs Delete (routef "/%d" (fun input _ ctx -> state.Delete.Value ctx (unbox<'Key> input) |> response<_> ctx))
-                | Float ->
-                  siteMap.AddPath "/%f" "DELETE"
-                  match typeof<'DeleteOutput> with
-                  | k when k = typeof<HttpContext option> -> yield addPlugs Delete (routef "/%f" (fun input _ ctx -> state.Delete.Value ctx (unbox<'Key> input) |> unbox<HttpFuncResult>))
-                  | _ -> yield addPlugs Delete (routef "/%f" (fun input _ ctx -> state.Delete.Value ctx (unbox<'Key> input) |> response<_> ctx))
-                | Guid ->
-                  siteMap.AddPath "/%O" "DELETE"
-                  match typeof<'DeleteOutput> with
-                  | k when k = typeof<HttpContext option> -> yield addPlugs Delete (routef "/%O" (fun input _ ctx -> state.Delete.Value ctx (unbox<'Key> input) |> unbox<HttpFuncResult>))
-                  | _ -> yield addPlugs Delete (routef "/%O" (fun input _ ctx -> state.Delete.Value ctx (unbox<'Key> input) |> response<_> ctx))
+              let path = "/"
+              let handler (ctx: HttpContext) = ctx.Request.Path <- PathString(ctx.Request.Path.ToString() + "/"); state.DeleteAll.Value(ctx)
+              addToSiteMap path
+              yield this.AddHandler state DeleteAll handler ""
+              yield this.AddHandler state DeleteAll handler path
+
+            if keyFormat.IsSome then
+              if state.Delete.IsSome then
+                let path = keyFormat.Value
+                addToSiteMap path
+                yield this.AddKeyHandler state Delete state.Delete.Value path
           ]
           if state.NotFoundHandler.IsSome then
             siteMap.NotFound ()
@@ -464,46 +276,18 @@ module Controller =
 
       let controllerWithSubs =
         choose [
-          for (sPath, sCs) in state.SubControllers do
-            match typ with
-            | None -> ()
-            | Some k ->
-              match k with
-              | Bool ->
-                let dummy = sCs (unbox<'Key> false)
-                siteMap.Forward ("/%b" + sPath) "" dummy
-                yield routef (PrintfFormat<bool -> obj, obj, obj, obj, bool>("/%b" + sPath)) (fun input -> subRoute ("/" + (string input) + sPath) (sCs (unbox<'Key> input)))
-                yield routef (PrintfFormat<bool -> string -> obj, obj, obj, obj, bool * string>("/%b" + sPath + "%s")) (fun (input, _) -> subRoute ("/" + (string input) + sPath) (sCs (unbox<'Key> input)))
-              | Char ->
-                let dummy = sCs (unbox<'Key> ' ')
-                siteMap.Forward ("/%c" + sPath) "" dummy
-                yield routef (PrintfFormat<char -> obj, obj, obj, obj, char>("/%c" + sPath)) (fun input -> subRoute ("/" + (string input) + sPath) (sCs (unbox<'Key> input)))
-                yield routef (PrintfFormat<char -> string -> obj, obj, obj, obj, char * string>("/%c" + sPath + "%s")) (fun (input, _) -> subRoute ("/" + (string input) + sPath) (sCs (unbox<'Key> input)))
-              | String ->
-                let dummy = sCs (unbox<'Key> "")
-                siteMap.Forward ("/%s" + sPath) "" dummy
-                yield routef (PrintfFormat<string -> obj, obj, obj, obj, string>("/%s" + sPath)) (fun input -> subRoute ("/" + (string input) + sPath) (sCs (unbox<'Key> input)))
-                yield routef (PrintfFormat<string -> string -> obj, obj, obj, obj, string * string>("/%s" + sPath + "%s")) (fun (input, _) -> subRoute ("/" + (string input) + sPath) (sCs (unbox<'Key> input)))
-              | Int32 ->
-                let dummy = sCs (unbox<'Key> 0)
-                siteMap.Forward ("/%i" + sPath) "" dummy
-                yield routef (PrintfFormat<int -> obj, obj, obj, obj, int>("/%i" + sPath)) (fun input -> subRoute ("/" + (string input) + sPath) (sCs (unbox<'Key> input)))
-                yield routef (PrintfFormat<int -> string -> obj, obj, obj, obj, int * string>("/%i" + sPath + "%s")) (fun (input, _) -> subRoute ("/" + (string input) + sPath) (sCs (unbox<'Key> input)))
-              | Int64 ->
-                let dummy = sCs (unbox<'Key> 0L)
-                siteMap.Forward ("/%d" + sPath) "" dummy
-                yield routef (PrintfFormat<int64 -> obj, obj, obj, obj, int64>("/%d" + sPath)) (fun input -> subRoute ("/" + (string input) + sPath) (sCs (unbox<'Key> input)))
-                yield routef (PrintfFormat<int64 -> string -> obj, obj, obj, obj, int64 * string>("/%d" + sPath + "%s")) (fun (input, _) -> subRoute ("/" + (string input) + sPath) (sCs (unbox<'Key> input)))
-              | Float ->
-                let dummy = sCs (unbox<'Key> 0.)
-                siteMap.Forward ("/%f" + sPath) "" dummy
-                yield routef (PrintfFormat<float -> obj, obj, obj, obj, float>("/%f" + sPath)) (fun input -> subRoute ("/" + (string input) + sPath) (sCs (unbox<'Key> input)))
-                yield routef (PrintfFormat<float -> string -> obj, obj, obj, obj, float * string>("/%f" + sPath + "%s")) (fun (input, _) -> subRoute ("/" + (string input) + sPath) (sCs (unbox<'Key> input)))
-              | Guid ->
-                let dummy = sCs (unbox<'Key> Guid.Empty)
-                siteMap.Forward ("/%O" + sPath) "" dummy
-                yield routef (PrintfFormat<obj -> obj, obj, obj, obj, obj>("/%O" + sPath)) (fun input -> subRoute ("/" + (string input) + sPath) (sCs (unbox<'Key> input)))
-                yield routef (PrintfFormat<obj -> string -> obj, obj, obj, obj, obj * string>("/%O" + sPath + "%s")) (fun (input, _) -> subRoute ("/" + (string input) + sPath) (sCs (unbox<'Key> input)))
+          if keyFormat.IsSome then
+            for (sPath, sCs) in state.SubControllers do
+              let path = keyFormat.Value
+              let dummy = sCs (unbox<'Key> Unchecked.defaultof<'Key>)
+              siteMap.Forward (path + sPath) "" dummy
+
+              yield routef (PrintfFormat<'Key -> obj,_,_,_,'Key> (path + sPath))
+                      (fun input -> subRoute ("/" + (input.ToString()) + sPath) (sCs (unbox<'Key> input)))
+
+              yield routef (PrintfFormat<'Key -> string -> obj,_,_,_,'Key * string> (path + sPath + "%s"))
+                      (fun input -> subRoute ("/" + (input.ToString()) + sPath) (sCs (unbox<'Key> input)))
+
           yield controllerWithErrorHandler
         ]
 

--- a/src/Saturn/Controller.fs
+++ b/src/Saturn/Controller.fs
@@ -50,7 +50,7 @@ module Controller =
   let inline response<'a> ctx (input : System.Threading.Tasks.Task<'a>) =
       task {
         let! i = input
-        return! Controller.resposne ctx i
+        return! Controller.response ctx i
       }
 
   type ControllerBuilder<'Key, 'IndexOutput, 'ShowOutput, 'AddOutput, 'EditOutput, 'CreateOutput, 'UpdateOutput, 'DeleteOutput, 'DeleteAllOutput> internal () =

--- a/src/Saturn/ControllerHelpers.fs
+++ b/src/Saturn/ControllerHelpers.fs
@@ -6,6 +6,8 @@ open Giraffe.Core
 open Giraffe.ResponseWriters
 open Giraffe.ModelBinding
 open FSharp.Control.Tasks.ContextInsensitive
+open Microsoft.Net.Http.Headers
+open Microsoft.Extensions.Primitives
 
 [<AutoOpen>]
 module ControllerHelpers =
@@ -39,6 +41,46 @@ module ControllerHelpers =
     ///Returns to the client static file.
     let file (ctx: HttpContext) path =
       ctx.WriteHtmlFileAsync path
+
+    ///Returns to the client response according to accepted content type (`Accept` header, and if it's not present `Content-Type` header)
+    let resposne (ctx: HttpContext) (output: 'a) =
+      let jsonMediaType = MediaTypeHeaderValue.Parse (StringSegment "application/json")
+      let xmlMediaType = MediaTypeHeaderValue.Parse (StringSegment "application/xml")
+      let plainMediaType = MediaTypeHeaderValue.Parse (StringSegment "text/plain")
+      let htmlMediaType = MediaTypeHeaderValue.Parse (StringSegment "text/html")
+
+      match ctx.Request.Headers.TryGetValue "Accept" with
+      | true, header ->
+        let mediaTypes = MediaTypeHeaderValue.ParseList header
+        if mediaTypes |> Seq.exists (jsonMediaType.IsSubsetOf) then ctx.WriteJsonAsync(output)
+        elif mediaTypes |> Seq.exists (xmlMediaType.IsSubsetOf) then ctx.WriteJsonAsync(output)
+        else
+          match typeof<'a> with
+          | k when k = typeof<string> && mediaTypes |> Seq.exists (plainMediaType.IsSubsetOf) -> ctx.WriteTextAsync(unbox<string> output)
+          | k when k = typeof<string> && mediaTypes |> Seq.exists (htmlMediaType.IsSubsetOf) -> ctx.WriteHtmlStringAsync(unbox<string> output)
+          | k when k = typeof<Giraffe.GiraffeViewEngine.XmlNode> && mediaTypes |> Seq.exists (htmlMediaType.IsSubsetOf) ->
+            ctx.WriteHtmlStringAsync (Giraffe.GiraffeViewEngine.renderXmlNode (unbox<_> output))
+          | _ -> failwithf "Couldn't recognize any known Accept type"
+      | _ ->
+      match ctx.Request.Headers.TryGetValue "Content-Type" with
+      | true, header ->
+        let mediaTypes = MediaTypeHeaderValue.ParseList header
+        if mediaTypes |> Seq.exists (jsonMediaType.IsSubsetOf) then ctx.WriteJsonAsync(output)
+        elif mediaTypes |> Seq.exists (xmlMediaType.IsSubsetOf) then ctx.WriteJsonAsync(output)
+        else
+          match typeof<'a> with
+          | k when k = typeof<string> && mediaTypes |> Seq.exists (plainMediaType.IsSubsetOf) -> ctx.WriteTextAsync(unbox<string> output)
+          | k when k = typeof<string> && mediaTypes |> Seq.exists (htmlMediaType.IsSubsetOf) -> ctx.WriteHtmlStringAsync(unbox<string> output)
+          | k when k = typeof<Giraffe.GiraffeViewEngine.XmlNode> && mediaTypes |> Seq.exists (htmlMediaType.IsSubsetOf) ->
+            ctx.WriteHtmlStringAsync (Giraffe.GiraffeViewEngine.renderXmlNode (unbox<_> output))
+          | _ -> failwithf "Couldn't recognize any known Content-Type type"
+      | _ ->
+        match typeof<'a> with
+        | k when k = typeof<Giraffe.GiraffeViewEngine.XmlNode> ->
+          ctx.WriteHtmlStringAsync (Giraffe.GiraffeViewEngine.renderXmlNode (unbox<_> output))
+        | k when k = typeof<string>  -> ctx.WriteTextAsync(unbox<string> output)
+        | _ -> ctx.WriteJsonAsync(output)
+
 
     ///Gets model from body as JSON.
     let getJson<'a> (ctx: HttpContext) =

--- a/src/Saturn/Saturn.fsproj
+++ b/src/Saturn/Saturn.fsproj
@@ -15,9 +15,9 @@
     <Compile Include="CSRF.fs" />
     <Compile Include="Pipelines.fs" />
     <Compile Include="Router.fs" />
+    <Compile Include="ControllerHelpers.fs" />
     <Compile Include="Controller.fs" />
     <Compile Include="Application.fs" />
-    <Compile Include="ControllerHelpers.fs" />
     <Compile Include="Authentication.fs" />
     <Compile Include="Links.fs" />
   </ItemGroup>


### PR DESCRIPTION
This extends controller CE to support generic output type from the controller actions. If action returns `Task<HttpContext option>`  nothing changes - it's non breaking change for existing code.

If action will return something else (`Task<'a>`) then we pipe `'a` through new `Controller.response` helper.

`Controller.response` helper is transforming any object to correct response that client expects. It checks `Accept` header (and if that's not available it checks `Content-Type` header) to find correct supported serialization format. 

We also support automatically returning `Giraffe.GiraffeViewEngine.XmlNode` which is Giraffe's server side view type. 