### PR TITLE
Fix 115 subcontroller behavior

### DIFF
--- a/src/Saturn/Controller.fs
+++ b/src/Saturn/Controller.fs
@@ -300,7 +300,7 @@ module Controller =
                       (fun input -> subRoute ("/" + (input.ToString()) + sPath) (sCs (unbox<'Key> input)))
 
               yield routef (PrintfFormat<'Key -> string -> obj,_,_,_,'Key * string> (path + sPath + "%s"))
-                      (fun input -> subRoute ("/" + (input.ToString()) + sPath) (sCs (unbox<'Key> input)))
+                      (fun (input,_) -> subRoute ("/" + (input.ToString()) + sPath) (sCs (unbox<'Key> input)))
 
           yield controllerWithErrorHandler
         ]

--- a/src/Saturn/Controller.fs
+++ b/src/Saturn/Controller.fs
@@ -277,6 +277,9 @@ module Controller =
           if keyFormat.IsSome then
             let stringConvert = stringConvert.Value
             for (sPath, sCs) in state.SubControllers do
+              if not (sPath.StartsWith("/")) then
+                failwith (sprintf "Subcontroller route '%s' is not valid, these routes should start with a '/'." sPath)
+
               let path = keyFormat.Value
               let dummy = sCs (unbox<'Key> Unchecked.defaultof<'Key>)
               siteMap.Forward (path + sPath) "" dummy


### PR DESCRIPTION
Rebased on top of pr of @TWith2Sugars.
Includes extra changes around string conversions of 'Key and a safety check for sub controller routes that don't start with a forward slash. 

These changes have been tested on nested controllers and on mixed key controllers.