### PR TITLE
Automatic dependency injection for controller

### DIFF
--- a/sample/Controller.Sample/Controller.Sample.fs
+++ b/sample/Controller.Sample/Controller.Sample.fs
@@ -5,22 +5,33 @@ open Giraffe.Core
 open Giraffe.ResponseWriters
 open Giraffe
 open System
+open Microsoft.Extensions.Logging
+
+type SampleDeps = {logger : ILogger}
 
 let commentController userId = controller {
-    index (fun ctx -> (sprintf "Comment Index handler for user %i" userId ) |> Controller.text ctx)
-    add (fun ctx -> (sprintf "Comment Add handler for user %i" userId ) |> Controller.text ctx)
-    show (fun ctx id -> (sprintf "Show comment %s handler for user %i" id userId ) |> Controller.text ctx)
-    edit (fun ctx id -> (sprintf "Edit comment %s handler for user %i" id userId )  |> Controller.text ctx)
+    index (fun ctx deps ->
+        deps.logger.LogInformation("Index Action")
+        (sprintf "Comment Index handler for user %i" userId ) |> Controller.text ctx)
+    add (fun ctx deps ->
+        deps.logger.LogInformation("Add Action")
+        (sprintf "Comment Add handler for user %i" userId ) |> Controller.text ctx)
+    show (fun ctx id deps ->
+        deps.logger.LogInformation("Show Action")
+        (sprintf "Show comment %s handler for user %i" id userId ) |> Controller.text ctx)
+    edit (fun ctx id deps ->
+        deps.logger.LogInformation("Edit Action")
+        (sprintf "Edit comment %s handler for user %i" id userId )  |> Controller.text ctx)
 }
 
 let userControllerVersion1 = controller {
     version "1"
     subController "/comments" commentController
 
-    index (fun ctx -> "Index handler version 1" |> Controller.text ctx)
-    add (fun ctx -> "Add handler version 1" |> Controller.text ctx)
-    show (fun ctx id -> (sprintf "Show handler version 1 - %i" id) |> Controller.text ctx)
-    edit (fun ctx id -> (sprintf "Edit handler version 1 - %i" id) |> Controller.text ctx)
+    index (fun ctx _-> "Index handler version 1" |> Controller.text ctx)
+    add (fun ctx _-> "Add handler version 1" |> Controller.text ctx)
+    show (fun ctx id _-> (sprintf "Show handler version 1 - %i" id) |> Controller.text ctx)
+    edit (fun ctx id _-> (sprintf "Edit handler version 1 - %i" id) |> Controller.text ctx)
 }
 
 let userController = controller {
@@ -29,13 +40,13 @@ let userController = controller {
     plug [All] (setHttpHeader "user-controller-common" "123")
     plug [Index; Show] (setHttpHeader "user-controller-specialized" "123")
 
-    index (fun ctx -> "Index handler no version" |> Controller.text ctx)
-    show (fun ctx id -> (sprintf "Show handler no version - %i" id) |> Controller.text ctx)
-    add (fun ctx -> "Add handler no version" |> Controller.text ctx)
-    create (fun ctx -> "Create handler no version" |> Controller.text ctx)
-    edit (fun ctx id -> (sprintf "Edit handler no version - %i" id) |> Controller.text ctx)
-    update (fun ctx id -> (sprintf "Update handler no version - %i" id) |> Controller.text ctx)
-    delete (fun ctx id -> failwith (sprintf "Delete handler no version failed - %i" id) |> Controller.text ctx)
+    index (fun ctx _-> "Index handler no version" |> Controller.text ctx)
+    show (fun ctx id _ -> (sprintf "Show handler no version - %i" id) |> Controller.text ctx)
+    add (fun ctx _ -> "Add handler no version" |> Controller.text ctx)
+    create (fun ctx _ -> "Create handler no version" |> Controller.text ctx)
+    edit (fun ctx id _ -> (sprintf "Edit handler no version - %i" id) |> Controller.text ctx)
+    update (fun ctx id _ -> (sprintf "Update handler no version - %i" id) |> Controller.text ctx)
+    delete (fun ctx id _ -> failwith (sprintf "Delete handler no version failed - %i" id) |> Controller.text ctx)
     error_handler (fun ctx ex -> sprintf "Error handler no version - %s" ex.Message |> Controller.text ctx)
 }
 
@@ -50,11 +61,11 @@ type DifferentResponse = {
 }
 
 let typedController = controller {
-    index (fun _ -> task {
+    index (fun _ _-> task {
         return {a = "hello"; b = "world"}
     })
 
-    add (fun _ -> task {
+    add (fun _ _ -> task {
         return {c = 123; d = DateTime.Now}
     })
 }


### PR DESCRIPTION
Dependency injection is part of .Net Core, and it’s the part that’s hard to ignore. While not idiomatic F# code, you just can’t get access to the framework _services_ (such as `ILogger`, or `IHostingEnv`) without DI. Giraffe “solves” this problem by adding `GetServixe<‘T>` function to `HttpContext`. However this is rather imperative way of doing things- you need to manually call function for each service you need. And fairly often this is the main activity that’s happening in the controller actions - user just gets those services and passes to the business logic code.

This PRs changes the signature of all controller actions adding additional parameter to it, that represent actions dependencies. Dependencies are modeled as F# type - ripple or record. Framework automatically creates instances of this type calling `GetService` for ever record field or tuple element, and then pass this instance to the action handler. This enables user to declaratively describe what dependencies action has.

What’s important is that ever action can have its own type for dependencies, meaning it can have its own dependency set.

Opinions and review welcomed.