### PR TITLE
Suggestion - set 404 status code on not found handlers in sample

### DIFF
--- a/sample/Saturn.Sample/Saturn.Sample.fs
+++ b/sample/Saturn.Sample/Saturn.Sample.fs
@@ -54,7 +54,7 @@ let endpointPipe = pipeline {
 
 let apiRouter = router {
     pipe_through apiHeaderPipe
-    not_found_handler (text "Api 404")
+    not_found_handler (setStatusCode 404 >=> text "Api 404")
 
     get "/" apiHelloWorld
     get "/a" apiHelloWorld2
@@ -96,7 +96,7 @@ let apiRouter = router {
 // delete - delete item
 
 let userController = controller {
-    not_found_handler (text "Users 404")
+    not_found_handler (setStatusCode 404 >=> text "Users 404")
 
     index (fun ctx -> "Index handler" |> Controller.text ctx)
     add (fun ctx -> "Add handler" |> Controller.text ctx)
@@ -110,7 +110,7 @@ let userController = controller {
 
 let topRouter = router {
     pipe_through headerPipe
-    not_found_handler (text "404")
+    not_found_handler (setStatusCode 404 >=> text "404")
 
     get "/" helloWorld
     get "/a" helloWorld2
@@ -119,7 +119,7 @@ let topRouter = router {
 
     forward "/other" (router {
         pipe_through otherHeaderPipe
-        not_found_handler (text "Other 404")
+        not_found_handler (setStatusCode 404 >=> text "Other 404")
 
         get "/" otherHelloWorld
         get "/a" otherHelloWorld2


### PR DESCRIPTION
This is a tiny one, but I'm looking for a spot to get my feet wet by making a small contribution. If this isn't helpful, feel free to disregard, or even better point me in a direction where I could be more helpful.
Thanks

It would be helpful if the sample set the 404 status code when using the not_found_handler. 

I used the sample as a starting point for my project and incorrectly assumed that the status code would be set automatically.
