### PR TITLE
cap giraffe dependency to prevent runtime errors

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -17,7 +17,7 @@ nuget Microsoft.AspNetCore.Authorization >= 2.1
 nuget Microsoft.AspNetCore.Antiforgery >= 2.1
 nuget Microsoft.AspNetCore.Server.HttpSys >= 2.1
 
-nuget Giraffe >= 1.1
+nuget Giraffe >= 1.1 < 3.0
 
 nuget Microsoft.NET.Sdk.Functions >= 1.0.19
 


### PR DESCRIPTION
Fixes #141 by capping the maximal giraffe version. The generated nuspec looks like this:
```xml
<?xml version="1.0" encoding="utf-8" standalone="yes"?>
<package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
  <metadata>
    <id>Saturn</id>
    <version>0.7.5</version>
    <title>Saturn</title>
    <authors>Krzysztof Cieslak</authors>
    <licenseUrl>https://github.com/Krzysztof-Cieslak/Saturn/blob/master/LICENSE.md</licenseUrl>
    <projectUrl>https://github.com/Krzysztof-Cieslak/Saturn</projectUrl>
    <iconUrl>https://avatars0.githubusercontent.com/u/35305523?s=200&amp;v=4</iconUrl>
    <description>Opinionated, web development framework for F# which implements the server-side, functional MVC pattern</description>
    <summary>Opinionated, web development framework for F# which implements the server-side, functional MVC pattern</summary>
    <releaseNotes>Check state.Urls before running UseUrls (by [@NinoFloris](https://github.com/NinoFloris))
fixes missing doctype in html controller actions (by [@WalternativE](https://github.com/WalternativE ))
Add abstraction for hosting Saturn on Azure Functions (by [@Krzysztof-Cieslak](https://github.com/Krzysztof-Cieslak))
Enable packaging for extensions (by [@Krzysztof-Cieslak](https://github.com/Krzysztof-Cieslak))</releaseNotes>
    <copyright>Copyright 2017 Lambda Factory</copyright>
    <tags>F# web framework ASP.Net Core HTTP Service MVC functional</tags>
    <dependencies>
      <dependency id="FSharp.Core" version="4.2.3" />
      <dependency id="Giraffe" version="[1.1.0,3.0.0)" />
      <dependency id="Microsoft.AspNetCore" version="2.1.0" />
      <dependency id="Microsoft.AspNetCore.Antiforgery" version="2.1.0" />
      <dependency id="Microsoft.AspNetCore.Authentication.Cookies" version="2.1.0" />
      <dependency id="Microsoft.AspNetCore.Authentication.JwtBearer" version="2.1.0" />
      <dependency id="Microsoft.AspNetCore.Authentication.OAuth" version="2.1.0" />
      <dependency id="Microsoft.AspNetCore.Authorization" version="2.1.0" />
      <dependency id="Microsoft.AspNetCore.Cors" version="2.1.0" />
      <dependency id="Microsoft.AspNetCore.ResponseCompression" version="2.1.0" />
      <dependency id="Microsoft.AspNetCore.Rewrite" version="2.1.0" />
      <dependency id="Microsoft.AspNetCore.Session" version="2.1.0" />
      <dependency id="Microsoft.AspNetCore.StaticFiles" version="2.1.0" />
      <dependency id="Microsoft.Extensions.Caching.Memory" version="2.1.0" />
    </dependencies>
  </metadata>
</package>
```

note the version range of `[1.1.0,3.0.0)` for Giraffe, which is an exclusive upper bound.