### PR TITLE
OAuth refactoring

### DIFF
--- a/src/Saturn/Authentication.fs
+++ b/src/Saturn/Authentication.fs
@@ -14,6 +14,28 @@ module ChallengeType =
     | Cookies
     | Custom of string
 
+module OAuth =
+
+  ///Record type representing simple OAuth configuration to be used with `use_oauth_with_settings`.
+  type OAuthSettings = {
+    ///Name of the schema to be registered
+    Schema: string
+    ///OAuth CallbackPath endpoint
+    CallbackPath: string
+    ///OAuth Authorization endpoint
+    ///For example: https://github.com/login/oauth/authorize
+    AuthorizationEndpoint: string
+    ///OAuth Token endpoint
+    ///For example: https://github.com/login/oauth/access_token
+    TokenEndpoint: string
+    ///OAuth User Information endpoint
+    ///For example: https://api.github.com/user
+    UserInformationEndpoint: string
+    ///Sequance of tuples where first element is a name of the of the key in JSON object and second element is a name of the claim.
+    ///For example: `["login", "githubUsername"; "name", "fullName"]` where `login` and `name` are names of fields in GitHub JSON response (https://developer.github.com/v3/users/#get-the-authenticated-user).
+    Claims : (string * string) seq
+  }
+
 module Auth =
   let private mapChallengeTypeToScheme = function
     | JWT -> Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerDefaults.AuthenticationScheme

--- a/src/Saturn/Router.fs
+++ b/src/Saturn/Router.fs
@@ -271,7 +271,7 @@ module Router =
     member __.CaseInsensitive (state) =
       {state with CaseInsensitive = true}
 
-  [<ObsoleteAttribute("This construct is obsolete, use router instead")>]
+  [<ObsoleteAttribute("This construct is obsolete, use `router` instead")>]
   let scope = RouterBuilder()
 
   let router = RouterBuilder()

--- a/src/Saturn/Saturn.fsproj
+++ b/src/Saturn/Saturn.fsproj
@@ -17,8 +17,8 @@
     <Compile Include="Router.fs" />
     <Compile Include="ControllerHelpers.fs" />
     <Compile Include="Controller.fs" />
-    <Compile Include="Application.fs" />
     <Compile Include="Authentication.fs" />
+    <Compile Include="Application.fs" />
     <Compile Include="Links.fs" />
   </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />


### PR DESCRIPTION
This is proof of concept for the suggestions discussed in https://github.com/SaturnFramework/Saturn/issues/96. CC: @rmunn

* Marks `use_custom_oauth` as obsolete
* Adds `use_oauth_with_config` instead. It's following naming conventions from other authentication methods (`use_cookies_authentication_with_config` and `use_jwt_authentication_with_config`).
* Adds `use_oauth` that takes simple record representing the usual OAuth settings and claims. 

