### PR TITLE
Controller key should always match up to a single path segment

### DIFF
--- a/src/Saturn/Controller.fs
+++ b/src/Saturn/Controller.fs
@@ -160,7 +160,7 @@ module Controller =
     ///Toggle case insensitve routing
     [<CustomOperation("case_insensitive")>]
     member __.CaseInsensitive (state) =
-      {state with CaseInsensitive = true}
+      {state with ControllerState.CaseInsensitive = true}
 
     ///Inject a controller into the routing table rooted at a given path. All of that controller's actions will be anchored off of the path as a prefix.
     [<CustomOperation("subController")>]

--- a/src/Saturn/Controller.fs
+++ b/src/Saturn/Controller.fs
@@ -227,41 +227,53 @@ module Controller =
         let d = x.GetDependency<'Dependency> ctx
         depHandler ctx d
 
-    member private __.AddHandlerWithRoute<'Output> state action (handler: HttpContext -> Task<'Output>) route =
-      let handler =
     member inline private  __.RouteFunc state route =
       if state.CaseInsensitive then routeCi route else Giraffe.Routing.route route
 
+    member inline private  __.FormattedRouteFunc state route routeHandler =
+      if state.CaseInsensitive then routeCif route routeHandler else routef route routeHandler
+
+    member private __.AddHandlerWithRouteHandler<'Output> state action (actionHandler: HttpContext -> Task<'Output>) routeHandler =
+      let actionHandler =
         match typeof<'Output> with
-        | k when k = typeof<HttpContext option> -> fun _ ctx -> handler ctx |> unbox<HttpFuncResult>
-        | _ -> fun _ ctx -> handler ctx |> response<'Output> ctx
+        | k when k = typeof<HttpContext option> -> fun _ ctx -> actionHandler ctx |> unbox<HttpFuncResult>
+        | _ -> fun _ ctx -> actionHandler ctx |> response<'Output> ctx
 
       match state.Plugs.TryFind action with
       | Some acts ->
         // Apply route test before applying plugs
         let plugs = succeed |> List.foldBack (fun e acc -> acc >=> e) acts
-        route >=> plugs >=> handler
-      | None -> route >=> handler
+        routeHandler >=> plugs >=> actionHandler
+      | None -> routeHandler >=> actionHandler
 
-    member private __.AddKeyHandler<'Output> state action (handler: HttpContext -> 'Key -> Task<'Output>) path =
-      let route =
-        if state.CaseInsensitive then
-          routeCif (PrintfFormat<_,_,_,_,'Key> path)
-        else
-          routef (PrintfFormat<_,_,_,_,'Key> path)
-
-      let handler =
+    member private x.AddKeyHandler<'Output> state action (actionHandler: HttpContext -> 'Key -> Task<'Output>) (route: string) =
+      let actionHandler : 'Key -> HttpHandler =
         match typeof<'Output> with
-        | k when k = typeof<HttpContext option> -> fun input _ ctx -> handler ctx (unbox<'Key> input) |> unbox<HttpFuncResult>
-        | _ -> fun input _ ctx -> handler ctx (unbox<'Key> input) |> response<'Output> ctx
+        | k when k = typeof<HttpContext option> -> fun input _ ctx -> actionHandler ctx (unbox<'Key> input) |> unbox<HttpFuncResult>
+        | _ -> fun input _ ctx -> actionHandler ctx (unbox<'Key> input) |> response<'Output> ctx
+
+      let routeHandler (actionHandler: 'Key -> HttpHandler) =
+        let routeHandler = x.FormattedRouteFunc state (PrintfFormat<_,_,_,_,'Key> route) actionHandler
+        // All 'Key types except string don't match "/" so they always stay within a single path segment by design.
+        if not (typeof<'Key> = typeof<string>)
+        then routeHandler else
+          let segmentRouteHandler =
+            // Open issue in Giraffe for a routStartsWithf https://github.com/giraffe-fsharp/Giraffe/issues/341
+            x.FormattedRouteFunc state (PrintfFormat<_,_,_,_,'Key * string> (route + "/%s")) (fst >> actionHandler)
+
+          fun next ctx ->
+            let hasTrailingSlash = (SubRouting.getNextPartOfPath ctx).LastIndexOf("/") = 0
+            // If we still have more segments beyond our current segment we'll only match up to the next "/".
+            // ASP.NET Core decodes everything but "/" characters for Request.Path, so we won't match those by accident here.
+            (if hasTrailingSlash then routeHandler else segmentRouteHandler) next ctx
 
       match state.Plugs.TryFind action with
       | Some acts ->
         // Apply route test before applying plugs
         let plugs = succeed |> List.foldBack (fun e acc -> acc >=> e) acts
-        route (fun key -> plugs >=> (handler key))
+        routeHandler (fun key -> plugs >=> (actionHandler key))
 
-      | None -> route handler
+      | None -> routeHandler actionHandler
 
     member this.Run (state: ControllerState<'Key, 'IndexOutput, 'ShowOutput, 'AddOutput, 'EditOutput, 'CreateOutput, 'UpdateOutput, 'PatchOutput, 'DeleteOutput, 'DeleteAllOutput>) : HttpHandler =
       let siteMap = HandlerMap()
@@ -303,11 +315,11 @@ module Controller =
             if state.Add.IsSome then
               let route = "/add"
               addToSiteMap route
-              yield this.AddHandlerWithRoute state Add state.Add.Value (this.RouteFunc state path)
+              yield this.AddHandlerWithRouteHandler state Add state.Add.Value (this.RouteFunc state route)
 
             if state.Index.IsSome then
               addToSiteMap "/"
-              yield this.AddHandlerWithRoute state Index state.Index.Value trailingSlashHandler
+              yield this.AddHandlerWithRouteHandler state Index state.Index.Value trailingSlashHandler
 
             if keyFormat.IsSome then
               if state.Edit.IsSome then
@@ -324,7 +336,7 @@ module Controller =
 
             if state.Create.IsSome then
               addToSiteMap "/"
-              yield this.AddHandlerWithRoute state Create state.Create.Value trailingSlashHandler
+              yield this.AddHandlerWithRouteHandler state Create state.Create.Value trailingSlashHandler
 
             if keyFormat.IsSome then
               if state.Update.IsSome then
@@ -355,7 +367,7 @@ module Controller =
 
             if state.DeleteAll.IsSome then
               addToSiteMap "/"
-              yield this.AddHandlerWithRoute state DeleteAll state.DeleteAll.Value trailingSlashHandler
+              yield this.AddHandlerWithRouteHandler state DeleteAll state.DeleteAll.Value trailingSlashHandler
 
             if keyFormat.IsSome then
               if state.Delete.IsSome then

--- a/tests/Saturn.UnitTests/ControllerTests.fs
+++ b/tests/Saturn.UnitTests/ControllerTests.fs
@@ -34,32 +34,35 @@ let testController = controller {
   update (updateAction None)
 }
 
+let testPathSegmentController = controller {
+  update (fun ctx (id: string) -> sprintf "Update %s" id |> Controller.text ctx)
+}
 
 [<Tests>]
 let routingTests =
-    let responseTestCase = responseTestCase testController
+    let responseTestCaseDefault = responseTestCase testController
 
     testList "Controller Routing Tests" [
         testCase "subController Update works" <|
-          responseTestCase "PUT" "/1/sub/2" "Update 1 2"
+          responseTestCaseDefault "PUT" "/1/sub/2" "Update 1 2"
 
         testCase "subController Create trailing slash works" <|
-          responseTestCase "POST" "/1/sub/" "Create 1"
+          responseTestCaseDefault "POST" "/1/sub/" "Create 1"
 
         testCase "subController Create no trailing slash works" <|
-          responseTestCase "POST" "/1/sub" "Create 1"
+          responseTestCaseDefault "POST" "/1/sub" "Create 1"
 
         testCase "Create trailing slash works" <|
-          responseTestCase "POST" "/" "Create"
+          responseTestCaseDefault "POST" "/" "Create"
 
         testCase "Create no trailing slash works" <|
-          responseTestCase "POST" "" "Create"
+          responseTestCaseDefault "POST" "" "Create"
 
         testCase "Update POST works" <|
-          responseTestCase "POST" "/1" "Update 1"
+          responseTestCaseDefault "POST" "/1" "Update 1"
 
         testCase "Update PUT works" <|
-          responseTestCase "PUT" "/1" "Update 1"
+          responseTestCaseDefault "PUT" "/1" "Update 1"
 
         testCase "deleteAll works" <| fun _ ->
             let expectedStatusCode = 204
@@ -106,6 +109,10 @@ let routingTests =
             | Some ctx ->
                 Expect.equal (ctx.Response.StatusCode) expectedStatusCode "Status code should be 204"
             Expect.equal plugged expectedString "Plugged should equal deleted"
+
+        testCase "Request `/test/1` returns `test` as controller's key handlers should match up to one path segment" <|
+          responseTestCase testPathSegmentController "PUT" "/test" "Update test"
+
 ]
 
 //---------------------------Plug tests----------------------------------------


### PR DESCRIPTION
Controller 'Key should always match up to a single path segment

See https://github.com/SaturnFramework/Saturn/issues/160#issuecomment-465747648 for bug, see code comments and tests for more explanation. 

I believe this is the right thing to do given the other 'Key type's routing behavior.