### PR TITLE
fix channel registration ordering so that channels happen before giraffe

### DIFF
--- a/sample/ChannelsSample/Program.fs
+++ b/sample/ChannelsSample/Program.fs
@@ -1,10 +1,11 @@
-﻿module WindowsAuthSample
+﻿module ChannelsSample
 
 open Saturn
 open Giraffe.ResponseWriters
 open Giraffe.Core
 open FSharp.Control.Tasks.V2
 open Saturn.Channels
+open Microsoft.Extensions.Logging
 
 
 
@@ -13,7 +14,10 @@ let browserRouter = router {
 }
 
 let sampleChannel = channel {
-    join (fun ctx -> task {return Ok})
+    join (fun ctx -> task {
+      ctx.GetLogger().LogInformation("Connected!")
+      return Ok
+    })
 
     handle "topic" (fun ctx res msg ->
         task {


### PR DESCRIPTION
It seems like you can't call `Configure` multiple times, because in my local testing of the channels feature I could never get a channel to negotiate!

This MR changes the registration order around a bit so that there's an explicit list of modifications that we build up with comments as to why they are layered in such a way.

With this, the channel sample works for me.