### PR TITLE
Remove trailing slash from Links.index

### DIFF
--- a/src/Saturn/Links.fs
+++ b/src/Saturn/Links.fs
@@ -13,7 +13,6 @@ module Links =
       | "" -> v
       | "edit" -> [| yield! v.[0 .. v.Length - 3 ]; yield "" |] //Remove 2 last parts of the path
       | _ -> [| yield! v.[0 .. v.Length - 2]; yield "" |] //Remove the last part of the path
-      |> String.concat "/"
     res
 
   ///Returns a link to the `add` action for the current model.


### PR DESCRIPTION
Help with #152 but this doesn't resolved the inconsistency in how trailing slashes are handled.