### PR TITLE
Allow all functions in a channel to see the socketId

### DIFF
--- a/sample/ChannelsSample/ChannelsSample.fs
+++ b/sample/ChannelsSample/ChannelsSample.fs
@@ -23,15 +23,15 @@ let browserRouter = router {
 }
 
 let sampleChannel = channel {
-    join (fun ctx id -> task {
-      ctx.GetLogger().LogInformation("Connected! Socket Id: " + id.ToString())
+    join (fun ctx si -> task {
+      ctx.GetLogger().LogInformation("Connected! Socket Id: " + si.SocketId.ToString())
       return Ok
     })
 
-    handle "topic" (fun ctx msg ->
+    handle "topic" (fun ctx si msg ->
         task {
             let logger = ctx.GetLogger()
-            logger.LogInformation("got message {message} from client", msg)
+            logger.LogInformation("got message {message} from client with Socket Id: {socketId}", msg, si.SocketId)
             return ()
         }
     )


### PR DESCRIPTION
Breaking change. Could be done in a none breaking way, by adding new operators to allow code to opt-in to see the socketId, but adds considerable complexity.
Added a SocketInfo record to wrap the SocketId, to allow more information about the socket to be added at a later date without a breaking change.