### PR TITLE
Added a few more mime-types that should be compressed.

### DIFF
--- a/src/Saturn/Application.fs
+++ b/src/Saturn/Application.fs
@@ -236,7 +236,18 @@ module Application =
     member __.UseGZip(state : ApplicationState) =
       let service (s : IServiceCollection) =
         s.Configure<GzipCompressionProviderOptions>(fun (opts : GzipCompressionProviderOptions) -> opts.Level <- System.IO.Compression.CompressionLevel.Optimal)
-         .AddResponseCompression()
+         .AddResponseCompression(fun o ->
+              // Note: By default there is setting: o.EnableForHttps <- false
+              // If your SSL-site doesn't contain any user sensitive data, consider changing that to true.
+              o.MimeTypes <- Seq.append o.MimeTypes [|
+                "application/x-yaml";
+                "image/svg+xml";
+                "application/octet-stream";
+                "application/x-font-ttf";
+                "application/x-font-opentype";
+                "application/x-javascript";
+                "text/javascript";
+              |])
       let middleware (app : IApplicationBuilder) = app.UseResponseCompression()
 
       { state with


### PR DESCRIPTION
The default list of compressable MIME-types is quite small:

https://docs.microsoft.com/en-us/aspnet/core/performance/response-compression?view=aspnetcore-3.1#mime-types

The types added in this PR are:
 - SVG images that are XML-files. Those are common and large text files
 - YAML-files. They are text-based resources, like dictionaries.
 - Uncompressed truetype-fonts, they can be large and they will compress quite well.
 - Default settings from Azure CDN compression enabled MIME-types.


