### PR TITLE
fix broken links in docs

### DIFF
--- a/docs/content/explanations/routing.fsx
+++ b/docs/content/explanations/routing.fsx
@@ -209,7 +209,7 @@ get "/3" (getApplication 3)
 ...
 ```
 
-But this is impracticle because there can be a large number of items or new items are constantly being created with new IDs. Instead the solution is to use format strings. Remember that in the [Adding Pages Guide](adding-pages.md), we used `getf "/%s" index2Action` to pass a string to page.
+But this is impracticle because there can be a large number of items or new items are constantly being created with new IDs. Instead the solution is to use format strings. Remember that in the [Adding Pages Guide](../tutorials/adding-pages.html), we used `getf "/%s" index2Action` to pass a string to page.
 
 | Format Char | Type |
 | ----------- | ---- |

--- a/docs/content/tutorials/adding-pages.md
+++ b/docs/content/tutorials/adding-pages.md
@@ -6,7 +6,7 @@ menu_order: 3
 
 # Adding Pages
 
-This guide uses the same project from the [how to start guide](how-to-start.md). Let's add two pages to it - one hello page and a page that can get your name from the URL.
+This guide uses the same project from the [how to start guide](how-to-start.html). Let's add two pages to it - one hello page and a page that can get your name from the URL.
 
 ## Creating the View
 

--- a/docs/content/tutorials/how-to-start.md
+++ b/docs/content/tutorials/how-to-start.md
@@ -45,7 +45,7 @@ run app
 
 If you compile and run this application, it will unconditionally return the text regardless of the path.
 
-From here on out you can add [routers](../explanations/routing.md), [controllers](../explanations/controller.md) and [views](../explanations/view.md).
+From here on out you can add [routers](../explanations/routing.html), [controllers](../explanations/controller.html) and [views](../explanations/view.html).
 
 ## Deep Dive
 


### PR DESCRIPTION
Some pages are linking to `.md` files that do not exist outside of the source repository, giving 404 errors.