### PR TITLE
Fix putSecureBrowserHeaders header typo

### DIFF
--- a/src/Saturn/Pipelines.fs
+++ b/src/Saturn/Pipelines.fs
@@ -177,7 +177,7 @@ module PipelineHelpers =
   ///  * x-download-options - set to noopen to instruct the browser not to open a download directly in the browser, to avoid HTML files rendering inline and accessing the security context of the application (like critical domain cookies)
   ///  * x-permitted-cross-domain-policies - set to none to restrict Adobe Flash Player’s access to data
   let putSecureBrowserHeaders : HttpHandler = pipeline {
-      set_header "x-frame-option" "SAMEORIGIN"
+      set_header "x-frame-options" "SAMEORIGIN"
       set_header "x-xss-protection" "1; mode=block"
       set_header "x-content-type-options" "nosniff"
       set_header "x-download-options" "noopen"


### PR DESCRIPTION
Looks like this header was incorrect as evidenced by the doc lines being the correct header. This should be `x-frame-options` according to [this](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options)