### PR TITLE
Add HEAD handling to router and controller

### DIFF
--- a/src/Saturn/ControllerEndpoint.fs
+++ b/src/Saturn/ControllerEndpoint.fs
@@ -37,9 +37,10 @@ module Controller =
       allSet - inputSet |> Set.toList
 
   ///Type representing internal state of the `controller` computation expression
-  type ControllerState<'Key, 'IndexOutput, 'ShowOutput, 'AddOutput, 'EditOutput, 'CreateOutput, 'UpdateOutput, 'PatchOutput, 'DeleteOutput, 'DeleteAllOutput> = {
+  type ControllerState<'Key, 'IndexOutput, 'ShowOutput, 'ExistsOutput, 'AddOutput, 'EditOutput, 'CreateOutput, 'UpdateOutput, 'PatchOutput, 'DeleteOutput, 'DeleteAllOutput> = {
     Index: (HttpContext -> Task<'IndexOutput>) option
     Show: (HttpContext -> 'Key -> Task<'ShowOutput>) option
+    Exists: (HttpContext -> 'Key -> Task<'ExistsOutput>) option
     Add: (HttpContext -> Task<'AddOutput>) option
     Edit: (HttpContext -> 'Key -> Task<'EditOutput>) option
     Create: (HttpContext -> Task<'CreateOutput>) option
@@ -104,10 +105,10 @@ module Controller =
   ///     edit (fun (ctx, id) -> (sprintf "Edit handler no version - %i" id) |> Controller.text ctx)
   /// }
   /// ```
-  type ControllerBuilder<'Key, 'IndexOutput, 'ShowOutput, 'AddOutput, 'EditOutput, 'CreateOutput, 'UpdateOutput, 'PatchOutput, 'DeleteOutput, 'DeleteAllOutput> internal () =
+  type ControllerBuilder<'Key, 'IndexOutput, 'ShowOutput, 'ExistsOutput, 'AddOutput, 'EditOutput, 'CreateOutput, 'UpdateOutput, 'PatchOutput, 'DeleteOutput, 'DeleteAllOutput> internal () =
 
-    member __.Yield(_) : ControllerState<'Key, 'IndexOutput, 'ShowOutput, 'AddOutput, 'EditOutput, 'CreateOutput, 'UpdateOutput, 'PatchOutput, 'DeleteOutput, 'DeleteAllOutput> =
-      { Index = None; Show = None; Add = None; Edit = None; Create = None; Update = None; Patch = None; Delete = None; DeleteAll = None; NotFoundHandler = None; Version = None; SubControllers = []; Plugs = Map.empty<_,_>; ErrorHandler = (fun _ ex -> raise ex); }
+    member __.Yield(_) : ControllerState<'Key, 'IndexOutput, 'ShowOutput, 'ExistsOutput, 'AddOutput, 'EditOutput, 'CreateOutput, 'UpdateOutput, 'PatchOutput, 'DeleteOutput, 'DeleteAllOutput> =
+      { Index = None; Show = None; Exists = None; Add = None; Edit = None; Create = None; Update = None; Patch = None; Delete = None; DeleteAll = None; NotFoundHandler = None; Version = None; SubControllers = []; Plugs = Map.empty<_,_>; ErrorHandler = (fun _ ex -> raise ex); }
 
     ///Operation that should render (or return in case of API controllers) list of data
     [<CustomOperation("index")>]
@@ -183,7 +184,7 @@ module Controller =
 
     ///Define not-found handler for the controller
     [<CustomOperation("not_found_handler")>]
-    member __.NotFoundHandler(state : ControllerState<_,_,_,_,_,_,_,_,_,_>, handler) =
+    member __.NotFoundHandler(state : ControllerState<_,_,_,_,_,_,_,_,_,_,_>, handler) =
       {state with NotFoundHandler = Some handler}
 
     ///Define error for the controller
@@ -375,7 +376,7 @@ module Controller =
 
       endpoint |> List.map (fun e -> e actionHandler)
 
-    member this.Run (state: ControllerState<'Key, 'IndexOutput, 'ShowOutput, 'AddOutput, 'EditOutput, 'CreateOutput, 'UpdateOutput, 'PatchOutput, 'DeleteOutput, 'DeleteAllOutput>) : Endpoint list =
+    member this.Run (state: ControllerState<'Key, 'IndexOutput, 'ShowOutput, 'ExistsOutput, 'AddOutput, 'EditOutput, 'CreateOutput, 'UpdateOutput, 'PatchOutput, 'DeleteOutput, 'DeleteAllOutput>) : Endpoint list =
       let isKnownKey =
         match state with
         | { Show = None; Edit = None; Update = None; Delete = None; Patch = None; SubControllers = [] } -> false
@@ -469,7 +470,7 @@ module Controller =
     ]
 
   ///Computation expression used to create controllers
-  let controller<'Key, 'IndexOutput, 'ShowOutput, 'AddOutput, 'EditOutput, 'CreateOutput, 'UpdateOutput, 'PatchOutput, 'DeleteOutput, 'DeleteAllOutput> = ControllerBuilder<'Key, 'IndexOutput, 'ShowOutput, 'AddOutput, 'EditOutput, 'CreateOutput, 'UpdateOutput, 'PatchOutput, 'DeleteOutput, 'DeleteAllOutput> ()
+  let controller<'Key, 'IndexOutput, 'ShowOutput, 'ExistsOutput, 'AddOutput, 'EditOutput, 'CreateOutput, 'UpdateOutput, 'PatchOutput, 'DeleteOutput, 'DeleteAllOutput> = ControllerBuilder<'Key, 'IndexOutput, 'ShowOutput, 'ExistsOutput, 'AddOutput, 'EditOutput, 'CreateOutput, 'UpdateOutput, 'PatchOutput, 'DeleteOutput, 'DeleteAllOutput> ()
 
   ///Computation expression used to create HttpHandlers representing subcontrollers.
-  let subcontroller<'Key, 'IndexOutput, 'ShowOutput, 'AddOutput, 'EditOutput, 'CreateOutput, 'UpdateOutput, 'PatchOutput, 'DeleteOutput, 'DeleteAllOutput> = Saturn.Controller.ControllerBuilder<'Key, 'IndexOutput, 'ShowOutput, 'AddOutput, 'EditOutput, 'CreateOutput, 'UpdateOutput, 'PatchOutput, 'DeleteOutput, 'DeleteAllOutput> ()
+  let subcontroller<'Key, 'IndexOutput, 'ShowOutput, 'ExistsOutput, 'AddOutput, 'EditOutput, 'CreateOutput, 'UpdateOutput, 'PatchOutput, 'DeleteOutput, 'DeleteAllOutput> = Saturn.Controller.ControllerBuilder<'Key, 'IndexOutput, 'ShowOutput, 'ExistsOutput, 'AddOutput, 'EditOutput, 'CreateOutput, 'UpdateOutput, 'PatchOutput, 'DeleteOutput, 'DeleteAllOutput> ()

--- a/src/Saturn/Router.fs
+++ b/src/Saturn/Router.fs
@@ -15,6 +15,8 @@ module Router =
   ///Type representing route type, used in internal state of the `application` computation expression
   type RouteType =
     | Get
+    | Head
+    | GetOrHead
     | Post
     | Put
     | Delete
@@ -145,6 +147,8 @@ module Router =
         let v =
           match typ with
           | RouteType.Get -> "GET"
+          | RouteType.Head -> "HEAD"
+          | RouteType.GetOrHead -> "GET_HEAD"
           | RouteType.Post -> "POST"
           | RouteType.Put -> "PUT"
           | RouteType.Patch -> "PATCH"
@@ -177,6 +181,8 @@ module Router =
         routes, routesf
 
       let gets, getsf = generateRoutes RouteType.Get
+      let heads, headsf = generateRoutes RouteType.Head
+      let getOrHeads, getOrHeadsf = generateRoutes RouteType.GetOrHead
       let posts, postsf = generateRoutes RouteType.Post
       let patches, patchesf = generateRoutes RouteType.Patch
 
@@ -211,6 +217,16 @@ module Router =
             yield GET >=> e
           for e in getsf do
             yield GET >=> e
+
+          for e in heads do
+            yield HEAD >=> e
+          for e in headsf do
+            yield HEAD >=> e
+
+          for e in getOrHeads do
+            yield GET_HEAD >=> e
+          for e in getOrHeadsf do
+            yield GET_HEAD >=> e
 
           for e in posts do
             yield POST >=> e
@@ -256,6 +272,26 @@ module Router =
     [<CustomOperation("getf")>]
     member __.GetF(state, path : PrintfFormat<_,_,_,_,'f>, action) : RouterState =
       addRouteF RouteType.Get state path action
+
+    ///Adds handler for `HEAD` request.
+    [<CustomOperation("head")>]
+    member __.Head(state, path : string, action: HttpHandler) : RouterState =
+      addRoute RouteType.Head state path action
+
+    ///Adds handler for `HEAD` request.
+    [<CustomOperation("headf")>]
+    member __.HeadF(state, path : PrintfFormat<_,_,_,_,'f>, action) : RouterState =
+      addRouteF RouteType.Head state path action
+
+    ///Adds handler for either `GET` or `HEAD` request.
+    [<CustomOperation("get_head")>]
+    member __.GetOrHead(state, path : string, action: HttpHandler) : RouterState =
+      addRoute RouteType.GetOrHead state path action
+
+    ///Adds handler for either `GET` or `HEAD` request.
+    [<CustomOperation("get_headf")>]
+    member __.GetOrHeadF(state, path : PrintfFormat<_,_,_,_,'f>, action) : RouterState =
+      addRouteF RouteType.GetOrHead state path action
 
     ///Adds handler for `POST` request.
     [<CustomOperation("post")>]


### PR DESCRIPTION
This is an initial implementation of #269, looking for feedback. Things I think should be added before this PR is ready to merge:

1\. Using `get_head` in the same router as either `get` or `head` is probably programmer error, as one of those handlers will trump the other one.

The way I wrote it, `get_head` is checked after `get` and `head`. So if you specify both `get` and `get_head`, but not `head`, in a router, then all GET requests will be handled by the `get` handler, and HEAD requests will be handled by the `get_head` handler. If you specify both `head` and `get_head`, but not `get`, then HEAD requests will be handled by the `head` handler while GET requests will be handled by the `get_head` handler. And if you specify all three, then the `get_head` handler will never be called.

I don't think the computation expression syntax will allow us to throw up a compile-time error if `get_head` is present in the same router as either `get` or `head`, but a runtime warning might be a good idea, as well as a note in the documentation.

2\. `exists` in controller currently doesn't dictate return type. Should it dictate a return type of `bool`? Or rather, `Task<bool>`?

If `exists` is written in the way I currently have it, where it handles a generic return type called `'ExistsOutput`, then the user is responsible for turning "Yes, the item exists" into a 200 OK response, and "No, it doesn't exist" into a 404 NOT FOUND response. (Or there might be other responses desired, such as 403 FORBIDDEN in some cases). If we change the `exists` operation to expect a function returning `Task<bool>`, then the user just has to return true (which Saturn would change to 200 OK) or false (which Saturn would change to 404 NOT FOUND). Simpler for the user, but someone wanting to return 403 FORBIDDEN would have to do that in a controller plugin since the `exists` operation wouldn't do it for him.

I'm leaning towards saying that the `exists` operation should expect a function returning `Task<bool>`, and then Saturn will take care of turning that into a 200/404 response. Would welcome feedback on this one.

3\. Unit tests are a good idea, and I haven't written them yet. Should test, among other things:

* `get_head` handles both GET and HEAD requests, and HEAD requests end up with bodiless responses thanks to what ASP.NET does for you. (That last part might be more of an acceptance test)
* `get_head` in same router as `head`: `head` handles HEAD requests while `get_head` handles GET requests
* `get_head` in same router as `get`: `get` handles GET requests while `get_head` handles HEAD requests
* `exists` in controller 

4\. Saturn documentation needs to be updated to document the new `head` and `get_head` operations in router CEs and `exists` in controller CEs.

I won't be able to work on documentation for a week or two, I think. If someone else wants to do it before then, I'd welcome the help.