### PR TITLE
fix issue #270: application/json not compressed in response

### DIFF
--- a/src/Saturn/Application.fs
+++ b/src/Saturn/Application.fs
@@ -284,7 +284,7 @@ module Application =
                 "application/x-javascript";
                 "text/javascript";
               |]
-              o.MimeTypes <- if not (isNull o.MimeTypes) then  Seq.append o.MimeTypes additionalMime else Seq.ofArray (additionalMime)
+              o.MimeTypes <- Seq.append ResponseCompressionDefaults.MimeTypes additionalMime
           )
       let middleware (app : IApplicationBuilder) = app.UseResponseCompression()
 


### PR DESCRIPTION
Add the additionalMime list to ResponseCompressionDefaults.MimeTypes.
(appearently the passed options do not contain the defaults)