### PR TITLE
typo fix: s/shortucts/shortcuts/

### DIFF
--- a/docs/generators/partials/menu.fsx
+++ b/docs/generators/partials/menu.fsx
@@ -97,7 +97,7 @@ let menu (ctx : SiteContents) (page: string) =
         ]
     ]
 
-  let renderShortucuts =
+  let renderShortcuts =
     section [Id "shortcuts"] [
         h3 [] [!! "Shortcuts"]
         ul [] [
@@ -139,7 +139,7 @@ let menu (ctx : SiteContents) (page: string) =
       if hasTutorials then renderTuts
       if hasHowTos then renderHowTos
       renderRefs
-      renderShortucuts
+      renderShortcuts
       renderFooter
     ]
   ]

--- a/docs/generators/partials/menu.fsx
+++ b/docs/generators/partials/menu.fsx
@@ -99,7 +99,7 @@ let menu (ctx : SiteContents) (page: string) =
 
   let renderShortucuts =
     section [Id "shortcuts"] [
-        h3 [] [!! "Shortucts"]
+        h3 [] [!! "Shortcuts"]
         ul [] [
           for s in shortcuts do
             yield


### PR DESCRIPTION
Typo fix in left navigation of Saturn documentation.
Also fix typo in function name.

![2021-02-11_18-52](https://user-images.githubusercontent.com/313058/107677306-66c6cc80-6c9a-11eb-969b-1fdfbb7b8e82.png)
