### PR TITLE
Remove automatic dependency injection for F# record fields, injecting…

### DIFF
--- a/src/Saturn/DependencyInjectionHelper.fs
+++ b/src/Saturn/DependencyInjectionHelper.fs
@@ -15,12 +15,7 @@ let buildDependencies<'Dependencies> (svcs: IServiceProvider) =
     res
 
   let getCtor (t: Type) : IServiceProvider -> obj =
-    if FSharpType.IsRecord t then
-      let fields = FSharpType.GetRecordFields t
-      fun svcs ->
-        let flds = fields |> Array.map (fun t -> getService svcs t.PropertyType)
-        FSharpValue.MakeRecord(t, flds)
-    elif FSharpType.IsTuple t then
+    if FSharpType.IsTuple t then
       let fields = FSharpType.GetTupleElements t
       fun svcs ->
         let fields = fields |> Array.map (getService svcs)

--- a/tests/Saturn.UnitTests/ControllerTests.fs
+++ b/tests/Saturn.UnitTests/ControllerTests.fs
@@ -285,19 +285,10 @@ let implicitConversionTest =
 
 //---------------------------Controller DI tests----------------------------------------
 
-type Dependency = {dep : IDependency}
-
 //Include _di operations in controller
 open ControllerDI
 
 let diController = controller {
-    index_di (fun ctx d ->
-        d.dep.Call ()
-        d.dep.Call ()
-        let v = d.dep.Value().ToString()
-        Controller.text ctx v
-    )
-
     show_di (fun ctx (d: IDependency) (id: int) ->
         d.Call ()
         d.Call ()
@@ -305,11 +296,10 @@ let diController = controller {
         Controller.text ctx v
     )
 
-    add_di (fun ctx (d: (IDependency * IDependency))->
-        let (d,_) = d
+    add_di (fun ctx (d: IDependency, d': IDependency) ->
         d.Call ()
-        d.Call ()
-        let v = d.Value().ToString()
+        d'.Call ()
+        let v = (d.Value() + d'.Value()).ToString()
         Controller.text ctx v
     )
 }
@@ -318,32 +308,20 @@ let diController = controller {
 let automaticDiTest =
     let responseTestCase = responseTestCase diController
     testList "Controller automatic DI" [
-        testCase "can inject record" <|
-            responseTestCase "GET" "/" "2"
-
         testCase "can inject interface" <|
             responseTestCase "GET" "/1" "3"
 
         testCase "can inject tupple" <|
-            responseTestCase "GET" "/add" "2"
+            responseTestCase "GET" "/add" "4"
     ]
 
 //---------------------------Router DI tests----------------------------------------
-
-type RoutDependency = {dep : IDependency}
 
 //Include _di operations in rouer
 open RouterDI
 open Giraffe
 
 let diRouter = router {
-    get_di "/" (fun d ->
-        d.dep.Call ()
-        d.dep.Call ()
-        let v = d.dep.Value().ToString()
-        text v
-    )
-
     getf_di "/%i" (fun (d: IDependency) (id: int) ->
         d.Call ()
         d.Call ()
@@ -351,11 +329,10 @@ let diRouter = router {
         text v
     )
 
-    get_di "/add" (fun (d: (IDependency * IDependency)) ->
-        let (d,_) = d
+    get_di "/add" (fun (d: IDependency, d': IDependency) ->
         d.Call ()
-        d.Call ()
-        let v = d.Value().ToString()
+        d'.Call ()
+        let v = (d.Value() + d'.Value()).ToString()
         text v
     )
 }
@@ -364,14 +341,11 @@ let diRouter = router {
 let routerDiTest =
     let responseTestCase = responseTestCase diRouter
     testList "Router automatic DI" [
-        testCase "can inject record" <|
-            responseTestCase "GET" "/" "2"
-
         testCase "can inject interface" <|
             responseTestCase "GET" "/1" "3"
 
         testCase "can inject tupple" <|
-            responseTestCase "GET" "/add" "2"
+            responseTestCase "GET" "/add" "4"
     ]
 
 //---------------------------Routing tests with string id----------------------------------------


### PR DESCRIPTION
… entire records instead

Injecting records looked like a good idea at first, since assigning names to parameters is a good thing. However, it causes a very big problem: What if we wanted to inject an entire record?

In F#, there are (AFAIK) two ways to create abstract sets of coherent operations:

* Use interfaces, and implement them with concrete types. Store data in fields.
* Use records containing functions. Implement operations by creating new instances of the record. Store data in closures.

Without going into detail about the pros and cons of each approach, I think we shouldn't force users of Saturn into using interfaces; and I can also think of a few other situations where injecting records could be useful.

Now, if we tried to inject this record:

```fsharp
type MyService = {
    AddInts: int -> int -> int
}

let myServiceFactory (logger: ILogger<MyService>) =
    {
        AddInts = fun x y ->
            logger.LogInformation("Adding two ints")
            x + y
    }
```

We'd get an error at runtime saying something like this: `No registered service for FSharpFunc<int, int, int>`. This is, of course, due to the dependency resolution code attempting to resolve each field of a record separately.

On the other hand, the argument for resolving record fields boils down to being able to name each dependency individually. After all, who'd want to write this?

```fsharp
get_di "/" (fun (d: IMyService * IMyOtherService * ILogger * IHttpClientFactory) ->
    let myService, myOtherService, logger, httpClientFactory = d
    ...
```

It's very highly unlikely that two functions would have the exact same dependencies. Record field resolution is best used with anonymous records:

```fsharp
get_di "/" (fun d: {| myService: IMyService; myOtherService: IMyOtherService; logger: ILogger; httpClientFactory: IHttpClientFactory |} -> ...)
```

However, this can more easily be accomplished using tuples like this:

```fsharp
get_di "/" (fun (myService: IMyService, myOtherService: IMyOtherService, logger: ILogger, httpClientFactory: IHttpClientFactory) -> ...)
```

There's also the fact that most people probably don't even *expect* fields of their record types to be resolved individually.

Given all of this, I feel the dependency resolution logic shouldn't attempt to resolve record fields. This change removes that logic and fixes the tests accordingly. I also modified the tuple tests to use individually named arguments, which looks much better than deconstruction.