### PR TITLE
lower fsharp.core dependency to 5.x so users can float

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -20,7 +20,9 @@ nuget protobuf-net.Grpc.AspNetCore
 nuget protobuf-net.Grpc.HttpClient
 nuget System.ServiceModel.Primitives
 nuget FSharp.Control.Websockets >= 0.2
-nuget FSharp.Core >= 4.2.3
+
+# as a library, saturn should have a lower min version of fsharp.core. users can float
+nuget FSharp.Core 5.0.0
 
 group Docs
   source https://api.nuget.org/v3/index.json

--- a/paket.lock
+++ b/paket.lock
@@ -37,7 +37,7 @@ NUGET
     FSharp.Control.Websockets (0.2.2)
       FSharp.Core (>= 4.3.4)
       Microsoft.IO.RecyclableMemoryStream (>= 1.2.2)
-    FSharp.Core (5.0.1)
+    FSharp.Core (5.0)
     Giraffe (5.0)
       FSharp.Core (>= 5.0)
       Giraffe.ViewEngine (>= 1.3)


### PR DESCRIPTION
Should fix #309 by lowering the version pinned in paket.dependencies.