### PR TITLE
Add test instructions to the README.md and fix the test instructions in the CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,7 +124,7 @@ in order to craft an excellent pull request:
 5. Make sure all the tests are still passing.
 
    ```bash
-   fake build
+   dotnet fake build -t Test
    ```
 
 6. Push your topic branch up to your fork:

--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ Saturn has nice [documentation](https://saturnframework.org/explanations/overvie
 2. Restore dotnet SDK tools: `dotnet tool restore`
 3. Inside the repo directory, run `dotnet fake build`
 
+## How to run the automated tests for this project
+
+Here we will present two ways of running the automated tests for this project. The first one is the preferred way since it is the same command used in the [CI build script](https://github.com/SaturnFramework/Saturn/blob/master/.github/workflows/build.yml#L23):
+
+* Inside the repo directory, run `dotnet fake build -t Test`.
+
+Although, there is this second approach where you can specify a test scenario to run filtering by its statement:
+
+1. Change the directory to the tests folder using `cd tests/Saturn.UnitTests/`
+2. List all the tests statements with this command: `dotnet run --list-tests`
+3. Run only one test scenario, filtering by the test statement like in this example: `dotnet run --filter "Controller Routing Tests.Add works"`.
+
 ## How to contribute
 
 *Imposter syndrome disclaimer*: I want your help. No really, I do.


### PR DESCRIPTION
I have noticed that the project lacks instructions about how to run the automated tests inside it. So I decided to contribute by providing a new section to the README.md where I teach people how to run those tests and how to run a specific test in cases where folks want to.

Also, I have fixed the CONTRIBUTING.md file where it shows a command to assert that all the tests are still passing. In this change, I just wrote basically the same thing I did for the README.md.