### PR TITLE
Fix #304

### DIFF
--- a/sample/gRpcSample.Client/Program.fs
+++ b/sample/gRpcSample.Client/Program.fs
@@ -3,14 +3,21 @@ open Shared
 open System
 open System.Net.Http
 open FSharp.Control.Tasks
+open Grpc.Net.Client
 
 [<EntryPoint>]
 let main _ =
     HttpClientExtensions.AllowUnencryptedHttp2 <- true
     task {
-        use http = new HttpClient (BaseAddress = Uri "http://localhost:10042")
-        let client = http.CreateGrpcService<ICalculator>()
-        let! result = client.MultiplyAsync { X = 12; Y = 4 }
+        use http = GrpcChannel.ForAddress("http://localhost:10042");
+        let calculatorClient = http.CreateGrpcService<ICalculator>()
+        let helloClient = http.CreateGrpcService<IHello>()
+
+        let! result = calculatorClient.MultiplyAsync { X = 12; Y = 4 }
         printfn "%i" result.Result
+        
+        let! r = helloClient.TestAsync { Parameter = "Saturn" }
+        printfn "%s" r.Response
+        
         return 0
     } |> fun t -> t.Result

--- a/sample/gRpcSample/Shared.fs
+++ b/sample/gRpcSample/Shared.fs
@@ -6,13 +6,30 @@ open System.Runtime.Serialization
 
 [<DataContract; CLIMutable>]
 type MultiplyRequest =
-    { [<DataMember(Order = 1)>] X : int
-      [<DataMember(Order = 2)>] Y : int }
+  { [<DataMember(Order = 1)>]
+    X: int
+    [<DataMember(Order = 2)>]
+    Y: int }
 
 [<DataContract; CLIMutable>]
 type MultiplyResult =
-    { [<DataMember(Order = 1)>] Result : int }
+  { [<DataMember(Order = 1)>]
+    Result: int }
+
+[<DataContract; CLIMutable>]
+type HelloRequest =
+  { [<DataMember(Order = 1)>]
+    Parameter: string }
+
+[<DataContract; CLIMutable>]
+type HelloResult =
+  { [<DataMember(Order = 1)>]
+    Response: string }
 
 [<ServiceContract(Name = "Hyper.Calculator")>]
 type ICalculator =
-    abstract MultiplyAsync : MultiplyRequest -> ValueTask<MultiplyResult>
+  abstract MultiplyAsync : MultiplyRequest -> ValueTask<MultiplyResult>
+
+[<ServiceContract(Name = "Hello.Test")>]
+type IHello =
+  abstract TestAsync : HelloRequest -> ValueTask<HelloResult>

--- a/sample/gRpcSample/gRpcSample.fs
+++ b/sample/gRpcSample/gRpcSample.fs
@@ -9,24 +9,32 @@ open System.Threading.Tasks
 open Giraffe
 
 type MyCalculator() =
-    interface ICalculator with
-        member __.MultiplyAsync request =
-            ValueTask<_> { Result = request.X * request.Y }
+  interface ICalculator with
+    member __.MultiplyAsync request =
+      ValueTask<_> { Result = request.X * request.Y }
 
 type MyCalculatorWithDI(serializer: Json.ISerializer) =
-    interface ICalculator with
-        member __.MultiplyAsync request =
-            printfn "Multiply reques serialized: %s" (serializer.SerializeToString request)
-            ValueTask<_> { Result = request.X * request.Y }
+  interface ICalculator with
+    member __.MultiplyAsync request =
+      printfn "Multiply requests serialized: %s" (serializer.SerializeToString request)
+      ValueTask<_> { Result = request.X * request.Y }
 
-let app = application {
-  no_router
-  listen_local 10042 (fun opts -> opts.Protocols <- HttpProtocols.Http2)
-  use_grpc MyCalculatorWithDI
-}
+
+type MyHelloWithDI(serializer: Json.ISerializer) =
+  interface IHello with
+    member __.TestAsync request =
+      ValueTask<_> { Response = $"Hello, {request.Parameter}!" }
+
+let app =
+  application {
+    no_router
+    listen_local 10042 (fun opts -> opts.Protocols <- HttpProtocols.Http2)
+    use_grpc MyHelloWithDI
+    use_grpc MyCalculatorWithDI
+  }
 
 
 [<EntryPoint>]
 let main _ =
-    run app
-    0 // return an integer exit code
+  run app
+  0 // return an integer exit code

--- a/src/Saturn.Extensions.gRPC/Saturn.gRPC.fs
+++ b/src/Saturn.Extensions.gRPC/Saturn.gRPC.fs
@@ -21,6 +21,6 @@ type Saturn.Application.ApplicationBuilder with
             app.UseEndpoints (fun endpoints -> endpoints.MapGrpcService<'a>() |> ignore)
 
         { state with
-            AppConfigs = configureApp::configureGrpcEndpoint::state.AppConfigs
+            AppConfigs = configureApp::configureGrpcEndpoint::state.AppConfigs.[1.. state.AppConfigs.Length]
             ServicesConfig = configureServices::state.ServicesConfig
         }


### PR DESCRIPTION
When use `use_grpc` a lot of times, the `configureApp` is added more times in appConfig making multiples sercices dont work corretly. 

Now `configureApp` is inserted only once. 

