### PR TITLE
Incorrect forwarding with common root at the same level

### DIFF
--- a/src/Saturn/Router.fs
+++ b/src/Saturn/Router.fs
@@ -232,8 +232,8 @@ module Router =
           for e in deletesf do
             yield DELETE >=> e
 
-          yield! forwards
           yield! forwardsf
+          yield! forwards
           if state.NotFoundHandler.IsSome then
             siteMap.NotFound ()
             yield state.NotFoundHandler.Value

--- a/tests/Saturn.UnitTests/RouterTests.fs
+++ b/tests/Saturn.UnitTests/RouterTests.fs
@@ -112,7 +112,7 @@ let caseInsensitiveTest =
 
   ]
 
-let wsId = System.Guid.NewGuid()
+let rootId = System.Guid.NewGuid()
 let root = "roots"
 
 let testForwardingRouter =
@@ -128,7 +128,7 @@ let testForwardingRouter =
 [<Tests>]
 let forwardingTests =
     testList "Common root forwarding tests" [
-        testCase "FORWARD to `/WORKSPACES` returns `workspaces`" <| fun _ ->
+        testCase "FORWARD to `/ROOTS` returns `roots`" <| fun _ ->
             let ctx = getEmptyContext "FORWARD" $"/{root}"
             let expected = root
             let result = testForwardingRouter next ctx |> runTask
@@ -138,9 +138,9 @@ let forwardingTests =
                 let body = (getBody ctx)
                 Expect.equal body expected "Result should be equal"
 
-        testCase $"FORWARD to `/WORKSPACES/{wsId}` returns `workspaces`" <| fun _ ->
-            let ctx = getEmptyContext "FORWARD" $"/{root}/{wsId}"
-            let expected = $"{root}/{wsId}"
+        testCase $"FORWARD to `/ROOTS/{rootId}` returns `roots/{rootId}`" <| fun _ ->
+            let ctx = getEmptyContext "FORWARD" $"/{root}/{rootId}"
+            let expected = $"{root}/{rootId}"
             let result = testForwardingRouter next ctx |> runTask
             match result with
             | None -> failtestf "Result was expected to be %s" expected

--- a/tests/Saturn.UnitTests/RouterTests.fs
+++ b/tests/Saturn.UnitTests/RouterTests.fs
@@ -111,3 +111,40 @@ let caseInsensitiveTest =
 
 
   ]
+
+let wsId = System.Guid.NewGuid()
+let root = "roots"
+
+let testForwardingRouter =
+    router {
+        forward $"/{root}" (fun next context ->
+            text $"{root}" next context
+            )
+        forwardf "/roots/%O" (fun id next context -> 
+            text (sprintf "roots/%O" id) next context
+            )
+    }
+
+[<Tests>]
+let forwardingTests =
+    testList "Common root forwarding tests" [
+        testCase "FORWARD to `/WORKSPACES` returns `workspaces`" <| fun _ ->
+            let ctx = getEmptyContext "FORWARD" $"/{root}"
+            let expected = root
+            let result = testForwardingRouter next ctx |> runTask
+            match result with
+            | None -> failtestf "Result was expected to be %s" expected
+            | Some ctx ->
+                let body = (getBody ctx)
+                Expect.equal body expected "Result should be equal"
+
+        testCase $"FORWARD to `/WORKSPACES/{wsId}` returns `workspaces`" <| fun _ ->
+            let ctx = getEmptyContext "FORWARD" $"/{root}/{wsId}"
+            let expected = $"{root}/{wsId}"
+            let result = testForwardingRouter next ctx |> runTask
+            match result with
+            | None -> failtestf "Result was expected to be %s" expected
+            | Some ctx ->
+                let body = (getBody ctx)
+                Expect.equal body expected "Result should be equal"
+    ]


### PR DESCRIPTION
Incorrect forwarding with common root at the same level
for example next routing will fail
`
router {
        forward $"/roots" (text "roots")
        forwardf "/roots/%O" (sprintf "roots/%O" >> text)
    }
`