### PR TITLE
Update `how-to-start` guide

### DIFF
--- a/docs/content/tutorials/how-to-start.md
+++ b/docs/content/tutorials/how-to-start.md
@@ -8,7 +8,7 @@ menu_order: 1
 
 Requirements:
 
-* `dotnet` SDK 3.1 [https://dotnet.microsoft.com/download/dotnet-core/3.1](https://dotnet.microsoft.com/download/dotnet-core/3.1)
+* `dotnet` SDK 6.0 - [link](https://dotnet.microsoft.com/download/dotnet-core/6.0)
 
 ## Template
 
@@ -21,7 +21,7 @@ The easiest way to get started is to use the provided template:
 6. Create a new controller with `dotnet saturn gen Book Books id:string title:string author:string`
 7. Run migrations that will create the database and Books table (as for now, the generator is using only SQLite DB) - `dotnet saturn migration`
 8. Open the folder in your favourite editor (VSCode) and insert the line (`forward "/books" Books.Controller.resource`) into `browserRouter` in `Router.fs` file
-9. Start the application by running `dotnet fake build -t run` from the root of the solution. This will start the application in watch mode (automatic recompilation on changes) and open your browser on [http://localhost:8085](http://localhost:8085) which should display the index page.
+9. Start the application by running `dotnet watch --project ./src/SaturnSample/` from the root of the solution. This will start the application in watch mode (automatic recompilation on changes - [documentation link](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-watch)) and open your browser on [http://localhost:8085](http://localhost:8085) which should display the index page.
 10. Go to [http://localhost:8085/books](http://localhost:8085/books) to see the generated view. All buttons should be working; you can add new entries, and remove or edit old ones.
 
 


### PR DESCRIPTION
## Description:

With this PR, I'm: 

* Updating the `how-to-start` guide due to the major .NET update of the project ([issue link](https://github.com/SaturnFramework/Saturn/issues/321)).
* Update the command used to start the sample application in watch mode. It was required to change due to the lack of [FAKE](https://github.com/fsprojects/FAKE) in the template.

---

This PR is related to this issue, where a user had difficulty to start using this tool:

* https://github.com/SaturnFramework/Saturn/issues/349

It is also linked to this other PR, where I sent some code to update the Saturn template and remove some broken configurations (they are broken in .NET 6, previously they were required):

* https://github.com/SaturnFramework/Saturn.Cli/pull/39