### PR TITLE
SimpleTests - Fix typo

### DIFF
--- a/tests/Saturn.UnitTests/SimpleTests.fs
+++ b/tests/Saturn.UnitTests/SimpleTests.fs
@@ -1,4 +1,4 @@
-module SimpleTets
+module SimpleTests
 
 open Expecto
 open Saturn
@@ -12,20 +12,19 @@ let somePost : HttpHandler =
   fun _ ctx ->
     task {
       let id = "myId"
-      let mkLinks x = [
+      let mkLinks () = [
         "myLink1"
         "myLink2"
       ]
 
-
       return!
         { id = id
-          links = mkLinks id }
+          links = mkLinks () }
         |> Response.accepted ctx
     }
 
 let router = router {
-    post "/" somePost
+  post "/" somePost
 }
 
 [<Tests>]


### PR DESCRIPTION
## Description:

With this PR I'm fixing a typo in the module name for the `SimpleTests.fs` file, along with other minor fixes in this file.

* Rename module: `SimpleTets` -> `SimpleTests`
* Remove empty line
* Change the `mkLinks` function to avoid receiving unused parameter
* Fix indentation for the router