### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -7,17 +7,23 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-latest]
+        os: [macos-12]
         dotnet: [6.0.200]
     runs-on: ${{ matrix.os }}
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: ${{ matrix.dotnet }}
+    - name: MacOS workaround
+      if: runner.os == 'macOS'
+      run: |
+          # https://github.com/actions/runner-images/issues/5768#issuecomment-1162684820
+          rm -rf ~/.config/NuGet/nuGet.config
+          dotnet nuget list source
     - name: Install wrk
       run: brew install wrk
     - name: Restore tools

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,17 +7,23 @@ jobs:
 
     strategy:
       matrix:
-        os: [windows-latest, macos-latest, ubuntu-latest]
+        os: [windows-2022, macos-12, ubuntu-22.04]
         dotnet: [6.0.200]
     runs-on: ${{ matrix.os }}
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: ${{ matrix.dotnet }}
+    - name: MacOS workaround
+      if: runner.os == 'macOS'
+      run: |
+          # https://github.com/actions/runner-images/issues/5768#issuecomment-1162684820
+          rm -rf ~/.config/NuGet/nuGet.config
+          dotnet nuget list source
     - name: Restore tools
       run: dotnet tool restore
     - name: Run Test

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,15 +8,15 @@ on:
 jobs:
   build:
 
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: [6.0.200]
+        dotnet-version: 6.0.200
     - name: Restore tools
       run: dotnet tool restore
     - name: Run Fornax

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,16 +10,16 @@ jobs:
 
     strategy:
       matrix:
-        os: [windows-latest]
+        os: [windows-2022]
         dotnet: [6.0.200]
     runs-on: ${{ matrix.os }}
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: ${{ matrix.dotnet }}
 


### PR DESCRIPTION
## Description:

With this PR I'm:

* Updating the version of both the `checkout` and `setup-dotnet` actions used.
* Pin the environment version to avoid problems popping up in the future due to some release (avoiding `latest` tags whenever possible).
* Add a workaround for the MacOS `dotnet tool restore`, which was failing.

Let me know if there is anything you'd like to change in this PR.

## Useful notes:

The MacOS workaround I found in this issue: https://github.com/actions/runner-images/issues/5768#issuecomment-1162684820. I added a new step to fix it when we're using MacOS as the host environment.

Other than this, one can find the actions mentioned before in the following links:

* checkout: https://github.com/actions/checkout
* setup-dotnet: https://github.com/actions/setup-dotnet

Finally, regarding the GitHub Actions host environment itself, one can find many details in this repository: https://github.com/actions/runner-images. It includes the possible versions, which tools are already installed there, etc.