### PR TITLE
Replace `master` branch references by `main` branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ Guidelines for bug reports:
    reported.
 
 2. **Check if the issue has been fixed** &mdash; try to reproduce it using the
-   `master` branch in the repository.
+   `main` branch in the repository.
 
 3. **Isolate and report the problem** &mdash; ideally create a reduced test
    case.
@@ -64,7 +64,6 @@ out whether your idea fits with the scope and aims of the project. It's up to *y
 to make a strong case to convince the community of the merits of this feature.
 Please provide as much detail and context as possible.
 
-
 ## Pull requests
 
 Good pull requests - patches, improvements, new features - are a fantastic
@@ -93,22 +92,22 @@ in order to craft an excellent pull request:
    # Navigate to the newly cloned directory
    cd Saturn
    # Assign the original repo to a remote called "upstream"
-   git remote add upstream https://github.com/Krzysztof-Cieslak/Saturn
+   git remote add upstream https://github.com/SaturnFramework/Saturn
    ```
 
 2. If you cloned a while ago, get the latest changes from upstream, and update your fork:
 
    ```bash
-   git checkout master
-   git pull upstream master
+   git checkout main
+   git pull upstream main
    git push
    ```
 
-3. Create a new topic branch (off of `master`) to contain your feature, change,
+3. Create a new topic branch (off of `main`) to contain your feature, change,
    or fix.
 
-   **IMPORTANT**: Making changes in `master` is discouraged. You should always
-   keep your local `master` in sync with upstream `master` and make your
+   **IMPORTANT**: Making changes in `main` is discouraged. You should always
+   keep your local `main` in sync with upstream `main` and make your
    changes in topic branches.
 
    ```bash
@@ -137,15 +136,15 @@ in order to craft an excellent pull request:
     with a clear title and description.
 
 8. If you haven't updated your pull request for a while, you should consider
-   rebasing on master and resolving any conflicts.
+   rebasing on main and resolving any conflicts.
 
-   **IMPORTANT**: _Never ever_ merge upstream `master` into your branches. You
-   should always `git rebase` on `master` to bring your changes up to date when
+   **IMPORTANT**: _Never ever_ merge upstream `main` into your branches. You
+   should always `git rebase` on `main` to bring your changes up to date when
    necessary.
 
    ```bash
-   git checkout master
-   git pull upstream master
+   git checkout main
+   git pull upstream main
    git checkout <your-topic-branch>
-   git rebase master
+   git rebase main
    ```

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Saturn has nice [documentation](https://saturnframework.org/explanations/overvie
 
 ## How to run the automated tests for this project
 
-Here we will present two ways of running the automated tests for this project. The first one is the preferred way since it is the same command used in the [CI build script](https://github.com/SaturnFramework/Saturn/blob/master/.github/workflows/build.yml#L23):
+Here we will present two ways of running the automated tests for this project. The first one is the preferred way since it is the same command used in the [CI build script](https://github.com/SaturnFramework/Saturn/blob/main/.github/workflows/build.yml#L23):
 
 * Inside the repo directory, run `dotnet run -- Test`.
 
@@ -40,7 +40,7 @@ There might be a little voice inside that tells you you're not ready; that you n
 
 I assure you, that's not the case.
 
-This project has some clear Contribution Guidelines and expectations that you can [read here](https://github.com/SaturnFramework/Saturn/blob/master/CONTRIBUTING.md).
+This project has some clear Contribution Guidelines and expectations that you can [read here](https://github.com/SaturnFramework/Saturn/blob/main/CONTRIBUTING.md).
 
 The contribution guidelines outline the process that you'll need to follow to get a patch merged. By making expectations and process explicit, I hope it will make it easier for you to contribute.
 
@@ -53,6 +53,6 @@ Thank you for contributing!
 The project is hosted on [GitHub](https://github.com/SaturnFramework/Saturn) where you can [report issues](https://github.com/SaturnFramework/Saturn/issues), fork
 the project and submit pull requests.
 
-The library is available under [MIT license](https://github.com/SaturnFramework/Saturn/blob/master/LICENSE.md), which allows modification and redistribution for both commercial and non-commercial purposes.
+The library is available under [MIT license](https://github.com/SaturnFramework/Saturn/blob/main/LICENSE.md), which allows modification and redistribution for both commercial and non-commercial purposes.
 
 Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.


### PR DESCRIPTION
## Description:

With this PR I'm basically replacing the references to the `master` branch in this repository by references to the `main` branch.