### PR TITLE
Added CustomOperation use_rewriter for URL Rewriting Middleware

### DIFF
--- a/src/Saturn/Application.fs
+++ b/src/Saturn/Application.fs
@@ -399,6 +399,18 @@ module Application =
 
       {state with AppConfigs=middleware::state.AppConfigs}
 
+    ///Enables usage of the URL Rewriting Middleware
+    ///If you used `force_ssl` operation, this option will override it. You'll have to specify "AddRedirectToHttps" on your RewriteOptions.
+    ///Usage example:
+    /// use_rewriter RewriteOptions().AddRedirectToNonWwwPermanent().AddRedirectToHttps()
+    ///For more information see https://learn.microsoft.com/en-us/aspnet/core/fundamentals/url-rewriting?view=aspnetcore-6.0
+    [<CustomOperation("use_rewriter")>]
+    member __.UseRewriter(state : ApplicationState, options : RewriteOptions) =
+      let middleware (app : IApplicationBuilder) =
+        app.UseRewriter options
+
+      {state with AppConfigs=middleware::state.AppConfigs}
+
     ///Enables application level CORS protection
     [<CustomOperation("use_cors")>]
     member __.UseCors(state: ApplicationState, policy : string, (policyConfig : CorsPolicyBuilder -> unit ) ) =


### PR DESCRIPTION
This pull request aims at adding the support for the URL Rewriting Middleware: https://learn.microsoft.com/en-us/aspnet/core/fundamentals/url-rewriting?view=aspnetcore-6.0.

The goal is to be able to add rewrite options directly from the ApplicationBuilder:
```fsharp
let rewriteOptions = RewriteOptions().AddRedirectToNonWwwPermanent()

application {
    use_rewriter rewriteOptions
}
```