### PR TITLE
Use char-based override instead of string in EndsWith

### DIFF
--- a/src/Saturn/Controller.fs
+++ b/src/Saturn/Controller.fs
@@ -230,7 +230,7 @@ module Controller =
             x.FormattedRouteFunc state (PrintfFormat<_,_,_,_,'Key * string> (route + "/%s")) (fst >> actionHandler)
 
           fun next ctx ->
-            let hasTrailingSlash = (SubRouting.getNextPartOfPath ctx).EndsWith '/'
+            let hasTrailingSlash = (SubRouting.getNextPartOfPath ctx).LastIndexOf '/' = 0
             // If we still have more segments beyond our current segment we'll only match up to the next "/".
             // ASP.NET Core decodes everything but "/" characters for Request.Path, so we won't match those by accident here.
             (if hasTrailingSlash then routeHandler else segmentRouteHandler) next ctx

--- a/src/Saturn/Controller.fs
+++ b/src/Saturn/Controller.fs
@@ -230,7 +230,7 @@ module Controller =
             x.FormattedRouteFunc state (PrintfFormat<_,_,_,_,'Key * string> (route + "/%s")) (fst >> actionHandler)
 
           fun next ctx ->
-            let hasTrailingSlash = (SubRouting.getNextPartOfPath ctx).LastIndexOf("/") = 0
+            let hasTrailingSlash = (SubRouting.getNextPartOfPath ctx).EndsWith '/'
             // If we still have more segments beyond our current segment we'll only match up to the next "/".
             // ASP.NET Core decodes everything but "/" characters for Request.Path, so we won't match those by accident here.
             (if hasTrailingSlash then routeHandler else segmentRouteHandler) next ctx
@@ -267,7 +267,7 @@ module Controller =
         let trailingSlashHandler : HttpHandler =
           fun next ctx ->
             let routeHandler = this.RouteFunc state "/"
-            if ctx.Request.Path.Value.EndsWith("/") then
+            if ctx.Request.Path.Value.EndsWith '/' then
               routeHandler next ctx
             else if (SubRouting.getNextPartOfPath ctx = "") then
               // TODO this could go away pending discussion about ctx.Request.route modification.
@@ -360,7 +360,7 @@ module Controller =
         choose [
           if keyFormat.IsSome then
             for (subRoute, sCs) in state.SubControllers do
-              if not (subRoute.StartsWith("/")) then
+              if not (subRoute.StartsWith '/') then
                 failwith (sprintf "Subcontroller route '%s' is not valid, these routes should start with a '/'." subRoute)
 
               let fullRoute = keyFormat.Value + subRoute

--- a/src/Saturn/ControllerEndpoint.fs
+++ b/src/Saturn/ControllerEndpoint.fs
@@ -368,7 +368,7 @@ module Controller =
         //   yield state.NotFoundHandler.Value
 
         for (subRoute, sCs) in state.SubControllers do
-          if not (subRoute.StartsWith("/")) then
+          if not (subRoute.StartsWith '/') then
             failwith (sprintf "Subcontroller route '%s' is not valid, these routes should start with a '/'." subRoute)
 
           let fullRoute = keyFormat() + subRoute
@@ -385,7 +385,7 @@ module Controller =
             routef (PrintfFormat<'Key -> obj,_,_,_,'Key> fullRoute) (fun key -> fun nxt ctx -> task {
               let v = ctx.Request.Path.Value
               let v =
-                if (v.EndsWith "/") then
+                if (v.EndsWith '/') then
                   v.Substring(0, v.Length - 1)
                 else
                   v


### PR DESCRIPTION
Tiny code clean-up.

Fix for CA1865-1867: https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1865-ca1867