### PR TITLE
add quick start to main html with code

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -134,6 +134,31 @@
 
                         </div>
                     </div>
+                    <div class="container">
+                        <div class="row">
+
+
+                            <!-- intro text -->
+                            <div>
+                                <h1>Quick Start</h1>
+                                <div>
+                                    <pre>
+                                        <code class="language-fsharp">
+                                        open Saturn
+                                        open Giraffe
+                                        
+                                        let app = application {
+                                            use_router (text "Hello World from Saturn")
+                                        }
+                                        
+                                        run app
+                                        </code>
+                                    </pre>
+                                </div>
+                            </div>
+
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
adds quick start to main html with code, sample for main idea, so that users have a quick way to start before diving into nested doc pages

<img width="753" alt="image" src="https://github.com/user-attachments/assets/b7598870-f91c-43fa-bfb2-ba5dcc81704f">